### PR TITLE
add BSM to compat packages

### DIFF
--- a/compat/bsm/sign.go
+++ b/compat/bsm/sign.go
@@ -1,0 +1,52 @@
+package bsm
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+
+	ec "github.com/bitcoin-sv/go-sdk/primitives/ec"
+	crypto "github.com/bitcoin-sv/go-sdk/primitives/hash"
+	"github.com/bitcoin-sv/go-sdk/transaction"
+)
+
+const hBSV = "Bitcoin Signed Message:\n"
+
+// SignMessage signs a string with the provided private key using Bitcoin Signed Message encoding
+// sigRefCompressedKey bool determines whether the signature will reference a compressed or uncompresed key
+// Spec: https://docs.moneybutton.com/docs/bsv-message.html
+func SignMessage(privateKey *ec.PrivateKey, message string, sigRefCompressedKey bool) (string, error) {
+	if privateKey == nil {
+		return "", errors.New("private key is required")
+	}
+
+	if len(message) == 0 {
+		return "", errors.New("message is required")
+	}
+
+	b := new(bytes.Buffer)
+	var err error
+
+	varInt := transaction.VarInt(len(hBSV))
+	b.Write(varInt.Bytes())
+
+	// append the hBsv to buff
+	b.WriteString(hBSV)
+
+	varInt = transaction.VarInt(len(message))
+	b.Write(varInt.Bytes())
+
+	// append the data to buff
+	b.WriteString(message)
+
+	// Create the hash
+	messageHash := crypto.Sha256d(b.Bytes())
+
+	// Sign
+	var sigBytes []byte
+	if sigBytes, err = ec.SignCompact(ec.S256(), privateKey, messageHash, sigRefCompressedKey); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(sigBytes), nil
+}

--- a/compat/bsm/sign.go
+++ b/compat/bsm/sign.go
@@ -12,9 +12,9 @@ import (
 
 const hBSV = "Bitcoin Signed Message:\n"
 
-// SignMessage signs a string with the provided private key using Bitcoin Signed Message encoding
+// SignMessage signs a string with the provided PrivateKey using Bitcoin Signed Message encoding
 // sigRefCompressedKey bool determines whether the signature will reference a compressed or uncompresed key
-// Spec: https://docs.moneybutton.com/docs/bsv-message.html
+// Spec: https://github.com/bitcoin/bitcoin/pull/524
 func SignMessage(privateKey *ec.PrivateKey, message string, sigRefCompressedKey bool) (string, error) {
 	if privateKey == nil {
 		return "", errors.New("private key is required")

--- a/compat/bsm/sign_test.go
+++ b/compat/bsm/sign_test.go
@@ -1,0 +1,160 @@
+package bsm
+
+import (
+	"fmt"
+	"testing"
+
+	ec "github.com/bitcoin-sv/go-sdk/primitives/ec"
+	"github.com/bitcoin-sv/go-sdk/script"
+)
+
+func TestSigningCompression(t *testing.T) {
+	testKey, _ := ec.PrivateKeyFromHex("0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd")
+	testData := "test message"
+
+	// Test sign uncompressed
+	// address, err := script.NewAddressFromPublicKey(testKey.PubKey(), false)
+	// if err != nil {
+	// 	t.Errorf("Get address err %s", err)
+	// }
+	// sig, err := SignMessage(testKey, testData, false)
+	// if err != nil {
+	// 	t.Errorf("Failed to sign uncompressed %s", err)
+	// }
+
+	// err = VerifyMessage(address, sig, testData)
+
+	// if err != nil {
+	// 	t.Errorf("Failed to validate uncompressed %s", err)
+	// }
+
+	// Test sign compressed
+	address, err := script.NewAddressFromPublicKey(testKey.PubKey(), true)
+	if err != nil {
+		t.Errorf("Get address err %s", err)
+	}
+	sig, err := SignMessage(testKey, testData, true)
+	if err != nil {
+		t.Errorf("Failed to sign compressed %s", err)
+	}
+
+	err = VerifyMessage(address.AddressString, sig, testData)
+
+	if err != nil {
+		t.Errorf("Failed to validate compressed %s", err)
+	}
+}
+
+// TestSignMessage will test the method SignMessage()
+func TestSignMessage(t *testing.T) {
+
+	t.Parallel()
+
+	var tests = []struct {
+		inputKey          string
+		inputMessage      string
+		expectedSignature string
+		expectedError     bool
+	}{
+		{
+			"0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd",
+			"test message",
+			"HFxPx8JHsCiivB+DW/RgNpCLT6yG3j436cUNWKekV3ORBrHNChIjeVReyAco7PVmmDtVD3POs9FhDlm/nk5I6O8=",
+			false,
+		},
+		{
+			"ef0b8bad0be285099534277fde328f8f19b3be9cadcd4c08e6ac0b5f863745ac",
+			"This is a test message",
+			"G+zZagsyz7ioC/ZOa5EwsaKice0vs2BvZ0ljgkFHxD3vGsMlGeD4sXHEcfbI4h8lP29VitSBdf4A+nHXih7svf4=",
+			false,
+		},
+		{
+			"0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd",
+			"This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af.",
+			"GxRcFXQc7LHxFNpK5lzhR+LF5ixIvhB089bxYzTAV02yGHm/3ALxltz/W4lGp77Q5UTxdj+TU+96mdAcJ5b/fGs=",
+			false,
+		},
+		{
+			"93596babb564cbbdc84f2370c710b9bcc94333495b60af719b5fcf9ba00ba82c",
+			"This is a test message",
+			"HIuDw09ffPgEDuxEw5yHVp1+mi4QpuhAwLyQdpMTfsHCOkMqTKXuP7dSNWMEJqZsiQ8eKMDRvf2wZ4e5bxcu4O0=",
+			false,
+		},
+		{
+			"50381cf8f52936faae4a05a073a03d688a9fa206d005e87a39da436c75476d78",
+			"This is a test message",
+			"HLBmbjCY2Z7eSXGXZoBI3x2ZRaYUYOGtEaDjXetaY+zNDtMOvagsOGEHnVT3f5kXlEbuvmPydHqLnyvZP3cDOWk=",
+			false,
+		},
+		{
+			"c7726663147afd1add392d129086e57c0b05aa66a6ded564433c04bd55741434",
+			"This is a test message",
+			"HOI207QUnTLr2Ll+s4kUxNgLgorkc/Z5Pc+XNvUBYLy2TxaU6oHEJ2TTJ1mZVrtUyHm6e315v1tIjeosW3Odfqw=",
+			false,
+		},
+		{
+			"c7726663147afd1add392d129086e57c0b05aa66a6ded564433c04bd55741434",
+			"1",
+			"HMcRFG1VNN9TDGXpCU+9CqKLNOuhwQiXI5hZpkTOuYHKBDOWayNuAABofYLqUHYTMiMf9mYFQ0sPgFJZz3F7ELQ=",
+			false,
+		},
+		{
+			"",
+			"This is a test message",
+			"",
+			true,
+		},
+		{
+			"0",
+			"This is a test message",
+			"",
+			true,
+		},
+		{
+			"0000000",
+			"This is a test message",
+			"",
+			true,
+		},
+		{
+			"c7726663147afd1add392d129086e57c0b",
+			"This is a test message",
+			"G6N+iPf23i2YkLsNzF/yyeBm9eSYBoY/HFV1Md1F0ElWBXW5E5mkdRtgjoRuq0yNb1CCFNWWlkn2gZknFJNUFJ8=",
+			false,
+		},
+	}
+
+	for idx, test := range tests {
+
+		testPk, errKey := ec.PrivateKeyFromHex(test.inputKey)
+
+		if signature, err := SignMessage(testPk, test.inputMessage, false); err != nil && !test.expectedError {
+			t.Fatalf("%d %s Failed: [%s] [%s] inputted and error not expected but got: %s", idx, t.Name(), test.inputKey, test.inputMessage, err.Error())
+		} else if err == nil && errKey == nil && test.expectedError {
+			t.Fatalf("%d %s Failed: [%s] [%s] inputted and error was expected", idx, t.Name(), test.inputKey, test.inputMessage)
+		} else if signature != test.expectedSignature {
+			t.Fatalf("%d %s Failed: [%s] [%s] inputted [%s] expected but got: %s", idx, t.Name(), test.inputKey, test.inputMessage, test.expectedSignature, signature)
+		}
+
+	}
+}
+
+// ExampleSignMessage example using SignMessage()
+func ExampleSignMessage() {
+	pk, _ := ec.PrivateKeyFromHex("ef0b8bad0be285099534277fde328f8f19b3be9cadcd4c08e6ac0b5f863745ac")
+	signature, err := SignMessage(pk, "This is a test message", false)
+	if err != nil {
+		fmt.Printf("error occurred: %s", err.Error())
+		return
+	}
+	fmt.Printf("signature created: %s", signature)
+	// Output:signature created: G+zZagsyz7ioC/ZOa5EwsaKice0vs2BvZ0ljgkFHxD3vGsMlGeD4sXHEcfbI4h8lP29VitSBdf4A+nHXih7svf4=
+}
+
+// BenchmarkSignMessage benchmarks the method SignMessage()
+func BenchmarkSignMessage(b *testing.B) {
+	key, _ := ec.NewPrivateKey()
+	for i := 0; i < b.N; i++ {
+		_, _ = SignMessage(key, "This is a test message", false)
+	}
+}

--- a/compat/bsm/sign_test.go
+++ b/compat/bsm/sign_test.go
@@ -12,22 +12,6 @@ func TestSigningCompression(t *testing.T) {
 	testKey, _ := ec.PrivateKeyFromHex("0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd")
 	testData := "test message"
 
-	// Test sign uncompressed
-	// address, err := script.NewAddressFromPublicKey(testKey.PubKey(), false)
-	// if err != nil {
-	// 	t.Errorf("Get address err %s", err)
-	// }
-	// sig, err := SignMessage(testKey, testData, false)
-	// if err != nil {
-	// 	t.Errorf("Failed to sign uncompressed %s", err)
-	// }
-
-	// err = VerifyMessage(address, sig, testData)
-
-	// if err != nil {
-	// 	t.Errorf("Failed to validate uncompressed %s", err)
-	// }
-
 	// Test sign compressed
 	address, err := script.NewAddressFromPublicKey(testKey.PubKey(), true)
 	if err != nil {

--- a/compat/bsm/verify.go
+++ b/compat/bsm/verify.go
@@ -1,0 +1,118 @@
+package bsm
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	ec "github.com/bitcoin-sv/go-sdk/primitives/ec"
+	crypto "github.com/bitcoin-sv/go-sdk/primitives/hash"
+	"github.com/bitcoin-sv/go-sdk/script"
+	"github.com/bitcoin-sv/go-sdk/transaction"
+)
+
+// PubKeyFromSignature gets a publickey for a signature and tells you whether is was compressed
+func PubKeyFromSignature(sig, data string) (pubKey *ec.PublicKey, wasCompressed bool, err error) {
+
+	var decodedSig []byte
+	if decodedSig, err = base64.StdEncoding.DecodeString(sig); err != nil {
+		return nil, false, err
+	}
+
+	// Validate the signature - this just shows that it was valid at all
+	// we will compare it with the key next
+	var buf bytes.Buffer
+	// if err = wire.WriteVarString(&buf, 0, hBSV); err != nil {
+	// 	return nil, false, err
+	// }
+	// if err = wire.WriteVarString(&buf, 0, data); err != nil {
+	// 	return nil, false, err
+	// }
+
+	varInt := transaction.VarInt(len(hBSV))
+	buf.Write(varInt.Bytes())
+	// append the hBsv to buff
+	buf.WriteString(hBSV)
+
+	varInt = transaction.VarInt(len(data))
+	buf.Write(varInt.Bytes())
+	// append the data to buff
+	buf.WriteString(data)
+
+	// Create the hash
+	expectedMessageHash := crypto.Sha256d(buf.Bytes())
+	return ec.RecoverCompact(decodedSig, expectedMessageHash)
+}
+
+// VerifyMessage verifies a string and address against the provided
+// signature and assumes Bitcoin Signed Message encoding.
+// The key referenced by the signature must relate to the address provided.
+// Do not provide an address from an uncompressed key along with
+// a signature from a compressed key
+//
+// Error will occur if verify fails or verification is not successful (no bool)
+// Spec: https://docs.moneybutton.com/docs/bsv-message.html
+func VerifyMessage(address, sig, data string) error {
+
+	// Reconstruct the pubkey
+	publicKey, wasCompressed, err := PubKeyFromSignature(sig, data)
+	if err != nil {
+		return err
+	}
+
+	// Get the address
+	var bscriptAddress *script.Address
+	if bscriptAddress, err = script.NewAddressFromPublicKey(publicKey, wasCompressed); err != nil {
+		return err
+	}
+
+	// Return nil if addresses match.
+	if bscriptAddress.AddressString == address {
+		return nil
+	}
+	return fmt.Errorf(
+		"address (%s) not found - compressed: %t\n%s was found instead",
+		address,
+		wasCompressed,
+		bscriptAddress.AddressString,
+	)
+}
+
+// VerifyMessageDER will take a message string, a public key string and a signature string
+// (in strict DER format) and verify that the message was signed by the public key.
+//
+// Copyright (c) 2019 Bitcoin Association
+// License: https://github.com/bitcoin-sv/merchantapi-reference/blob/master/LICENSE
+//
+// Source: https://github.com/bitcoin-sv/merchantapi-reference/blob/master/handler/global.go
+func VerifyMessageDER(hash [32]byte, pubKey string, signature string) (verified bool, err error) {
+
+	// Decode the signature string
+	var sigBytes []byte
+	if sigBytes, err = hex.DecodeString(signature); err != nil {
+		return
+	}
+
+	// Parse the signature
+	var sig *ec.Signature
+	if sig, err = ec.ParseDERSignature(sigBytes); err != nil {
+		return
+	}
+
+	// Decode the pubKey
+	var pubKeyBytes []byte
+	if pubKeyBytes, err = hex.DecodeString(pubKey); err != nil {
+		return
+	}
+
+	// Parse the pubKey
+	var rawPubKey *ec.PublicKey
+	if rawPubKey, err = ec.ParsePubKey(pubKeyBytes); err != nil {
+		return
+	}
+
+	// Verify the signature against the pubKey
+	verified = sig.Verify(hash[:], rawPubKey)
+	return
+}

--- a/compat/bsm/verify.go
+++ b/compat/bsm/verify.go
@@ -75,11 +75,6 @@ func VerifyMessage(address, sig, data string) error {
 
 // VerifyMessageDER will take a message string, a public key string and a signature string
 // (in strict DER format) and verify that the message was signed by the public key.
-//
-// Copyright (c) 2019 Bitcoin Association
-// License: https://github.com/bitcoin-sv/merchantapi-reference/blob/master/LICENSE
-//
-// Source: https://github.com/bitcoin-sv/merchantapi-reference/blob/master/handler/global.go
 func VerifyMessageDER(hash [32]byte, pubKey string, signature string) (verified bool, err error) {
 
 	// Decode the signature string

--- a/compat/bsm/verify.go
+++ b/compat/bsm/verify.go
@@ -23,12 +23,6 @@ func PubKeyFromSignature(sig, data string) (pubKey *ec.PublicKey, wasCompressed 
 	// Validate the signature - this just shows that it was valid at all
 	// we will compare it with the key next
 	var buf bytes.Buffer
-	// if err = wire.WriteVarString(&buf, 0, hBSV); err != nil {
-	// 	return nil, false, err
-	// }
-	// if err = wire.WriteVarString(&buf, 0, data); err != nil {
-	// 	return nil, false, err
-	// }
 
 	varInt := transaction.VarInt(len(hBSV))
 	buf.Write(varInt.Bytes())
@@ -52,7 +46,7 @@ func PubKeyFromSignature(sig, data string) (pubKey *ec.PublicKey, wasCompressed 
 // a signature from a compressed key
 //
 // Error will occur if verify fails or verification is not successful (no bool)
-// Spec: https://docs.moneybutton.com/docs/bsv-message.html
+// Spec: https://github.com/bitcoin/bitcoin/pull/524
 func VerifyMessage(address, sig, data string) error {
 
 	// Reconstruct the pubkey

--- a/message/encrypted.go
+++ b/message/encrypted.go
@@ -11,10 +11,9 @@ import (
 )
 
 // BRC-78: https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0078.md
-// TODO: According to spec this should be 0x10334242
-// const VERSION = "42421033"
-const VERSION = "10334242" // FIXME: remove later if not needed
-var VERSION_BYTES = []byte{0x10, 0x33, 0x42, 0x42}
+const VERSION = "42421033"
+
+var VERSION_BYTES = []byte{0x42, 0x42, 0x10, 0x33}
 
 // Encrypt encrypts a message using the sender's private key and the recipient's public key.
 func Encrypt(message []byte, sender *ec.PrivateKey, recipient *ec.PublicKey) ([]byte, error) {

--- a/message/encrypted_test.go
+++ b/message/encrypted_test.go
@@ -1,64 +1,76 @@
 package message
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	ec "github.com/bitcoin-sv/go-sdk/primitives/ec"
 )
 
-// TODO - implement go version
-// import { encrypt, decrypt } from '../../../dist/cjs/src/messages/EncryptedMessage'
-// import PrivateKey from '../../../dist/cjs/src/primitives/PrivateKey'
-
-// describe('EncryptedMessage', () => {
-//   it('Encrypts a message for a recipient', () => {
-//     const sender = new PrivateKey(15)
-//     const recipient = new PrivateKey(21)
-//     const recipientPub = recipient.toPublicKey()
-//     const message = [1, 2, 4, 8, 16, 32]
-//     const encrypted = encrypt(message, sender, recipientPub)
-//     const decrypted = decrypt(encrypted, recipient)
-//     expect(decrypted).toEqual(message)
-//   })
-//   it('Fails to decrypt a message with wrong version', () => {
-//     const sender = new PrivateKey(15)
-//     const recipient = new PrivateKey(21)
-//     const recipientPub = recipient.toPublicKey()
-//     const message = [1, 2, 4, 8, 16, 32]
-//     const encrypted = encrypt(message, sender, recipientPub)
-//     encrypted[0] = 1
-//     expect(() => decrypt(encrypted, recipient)).toThrow(new Error(
-//       'Message version mismatch: Expected 42421033, received 01421033'
-//     ))
-//   })
-//   it('Fails to decrypt a message with wrong recipient', () => {
-//     const sender = new PrivateKey(15)
-//     const recipient = new PrivateKey(21)
-//     const wrongRecipient = new PrivateKey(22)
-//     const recipientPub = recipient.toPublicKey()
-//     const message = [1, 2, 4, 8, 16, 32]
-//     const encrypted = encrypt(message, sender, recipientPub)
-//     expect(() => decrypt(encrypted, wrongRecipient)).toThrow(new Error(
-//       'The encrypted message expects a recipient public key of 02352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5, but the provided key is 03421f5fc9a21065445c96fdb91c0c1e2f2431741c72713b4b99ddcb316f31e9fc'
-//     ))
-//   })
-// })
-
 func TestEncryptedMessage(t *testing.T) {
-	sender, _ := ec.PrivateKeyFromBytes([]byte{15})
-	recipient, recipientPub := ec.PrivateKeyFromBytes([]byte{21})
+	t.Run("Encrypts a message for a recipient", func(t *testing.T) {
+		sender, _ := ec.PrivateKeyFromBytes([]byte{15})
+		recipient, recipientPub := ec.PrivateKeyFromBytes([]byte{21})
 
-	msg := []byte{1, 2, 4, 8, 16, 32}
+		msg := []byte{1, 2, 4, 8, 16, 32}
 
-	encrypted, err := Encrypt(msg, sender, recipientPub)
-	if err != nil {
-		t.Fatalf("Error encrypting message: %v", err)
-	}
-	decrypted, err := Decrypt(encrypted, recipient)
-	if err != nil {
-		t.Fatalf("Error decrypting message: %v", err)
-	}
-	if string(decrypted) != string(msg) {
-		t.Errorf("Decrypted message does not match original message")
-	}
+		encrypted, err := Encrypt(msg, sender, recipientPub)
+		if err != nil {
+			t.Fatalf("Error encrypting message: %v", err)
+		}
+		decrypted, err := Decrypt(encrypted, recipient)
+		if err != nil {
+			t.Fatalf("Error decrypting message: %v", err)
+		}
+		if !bytes.Equal(decrypted, msg) {
+			t.Errorf("Decrypted message does not match original message")
+		}
+	})
+
+	t.Run("Fails to decrypt a message with wrong version", func(t *testing.T) {
+		sender, _ := ec.PrivateKeyFromBytes([]byte{15})
+		recipient, recipientPub := ec.PrivateKeyFromBytes([]byte{21})
+
+		msg := []byte{1, 2, 4, 8, 16, 32}
+
+		encrypted, err := Encrypt(msg, sender, recipientPub)
+		if err != nil {
+			t.Fatalf("Error encrypting message: %v", err)
+		}
+
+		// Modify the version
+		encrypted[0] = 1
+
+		_, err = Decrypt(encrypted, recipient)
+		if err == nil {
+			t.Fatalf("Expected an error, but got none")
+		}
+		expectedError := "message version mismatch: Expected 42421033, received 01421033"
+		if err.Error() != expectedError {
+			t.Errorf("Expected error: %s, but got: %s", expectedError, err.Error())
+		}
+	})
+
+	t.Run("Fails to decrypt a message with wrong recipient", func(t *testing.T) {
+		sender, _ := ec.PrivateKeyFromBytes([]byte{15})
+		_, recipientPub := ec.PrivateKeyFromBytes([]byte{21})
+		wrongRecipient, _ := ec.PrivateKeyFromBytes([]byte{22})
+
+		msg := []byte{1, 2, 4, 8, 16, 32}
+
+		encrypted, err := Encrypt(msg, sender, recipientPub)
+		if err != nil {
+			t.Fatalf("Error encrypting message: %v", err)
+		}
+
+		_, err = Decrypt(encrypted, wrongRecipient)
+		if err == nil {
+			t.Fatalf("Expected an error, but got none")
+		}
+		expectedError := fmt.Sprintf("the encrypted message expects a recipient public key of %x, but the provided key is %x", recipientPub.SerialiseCompressed(), wrongRecipient.PubKey().SerialiseCompressed())
+		if err.Error() != expectedError {
+			t.Errorf("Expected error: %s, but got: %s", expectedError, err.Error())
+		}
+	})
 }

--- a/message/signed_test.go
+++ b/message/signed_test.go
@@ -43,7 +43,7 @@ func TestSignedMessage(t *testing.T) {
 
 		_, err := Verify(message, signature, recipientPriv)
 		assert.NotNil(t, err)
-		assert.Equal(t, "message version mismatch: Expected 10334242, received 01334242", err.Error())
+		assert.Equal(t, "message version mismatch: Expected 42421033, received 01421033", err.Error())
 	})
 
 }

--- a/primitives/ec/privatekey.go
+++ b/primitives/ec/privatekey.go
@@ -68,7 +68,13 @@ func NewPrivateKey() (*PrivateKey, error) {
 
 // PrivateKey is an ecdsa.PrivateKey with additional functions to
 func PrivateKeyFromHex(privKeyHex string) (*PrivateKey, error) {
-	privKeyBytes, _ := hex.DecodeString(privKeyHex)
+	if len(privKeyHex) == 0 {
+		return nil, errors.New("private key hex is empty")
+	}
+	privKeyBytes, err := hex.DecodeString(privKeyHex)
+	if err != nil {
+		return nil, err
+	}
 	privKey, _ := PrivateKeyFromBytes(privKeyBytes)
 	return privKey, nil
 }


### PR DESCRIPTION
- add BSM package (Bitcoin Signed Message)
- add BSM tests for sign and verify
- return errors when creating private keys from hex including 0 length
- BRC-78 fixed wrong version based on incorrect ts docs (ts docs have been updated)
- Implement remaining BRC-78 tests