### PR TITLE
fix: minor polishing - found when implementing it in SPV-Wallet

### DIFF
--- a/primitives/ec/field.go
+++ b/primitives/ec/field.go
@@ -71,10 +71,6 @@ const (
 	// 2^(fieldBase*i) where i is the word position.
 	fieldBase = 26
 
-	// fieldOverflowBits is the minimum number of "overflow" bits for each
-	// word in the field value.
-	fieldOverflowBits = 32 - fieldBase //nolint:varcheck,deadcode,unused // reasons.
-
 	// fieldBaseMask is the mask for the bits in each word needed to
 	// represent the numeric base of each word (except the most significant
 	// word).

--- a/primitives/ec/privatekey.go
+++ b/primitives/ec/privatekey.go
@@ -253,7 +253,7 @@ func (p *PrivateKey) ToKeyShares(threshold int, totalShares int) (keyShares *key
 	}
 
 	points := make([]*keyshares.PointInFiniteField, 0)
-	for i := 0; i < totalShares; i++ {
+	for range totalShares {
 		pk, err := NewPrivateKey()
 		if err != nil {
 			return nil, err

--- a/primitives/ec/privatekey.go
+++ b/primitives/ec/privatekey.go
@@ -253,7 +253,7 @@ func (p *PrivateKey) ToKeyShares(threshold int, totalShares int) (keyShares *key
 	}
 
 	points := make([]*keyshares.PointInFiniteField, 0)
-	for range totalShares {
+	for i := 0; i < totalShares; i++ {
 		pk, err := NewPrivateKey()
 		if err != nil {
 			return nil, err

--- a/script/script_chunk.go
+++ b/script/script_chunk.go
@@ -215,7 +215,7 @@ func PushDataPrefix(data []byte) ([]byte, error) {
 	return b, nil
 }
 
-// DecodeStringParts takes a hex string and decodes the opcodes in it
+// DecodeScriptHex takes a hex string and decodes the opcodes in it
 // returning an array of opcode parts (which could be opcodes or data
 // pushed to the stack).
 func DecodeScriptHex(s string) ([]*ScriptChunk, error) {


### PR DESCRIPTION
This pull request includes several changes to improve code readability and functionality in the `primitives/ec` and `script` packages. The most important changes include removing unused variables, fixing a loop initialization, and renaming a function for clarity.

Code readability and cleanup:

* [`primitives/ec/field.go`](diffhunk://#diff-253b04d1fb788fe790f1d53b22c98b30a9fa1b184987fd43c10067be9b7c8083L74-L77): Removed the unused `fieldOverflowBits` variable to clean up the code.

Code clarity:

* [`script/script_chunk.go`](diffhunk://#diff-bf1473a8dddb5660e234992873dacb02182747409a8dc9aa10de190708fcb3c8L218-R218): Renamed the `DecodeStringParts` function to `DecodeScriptHex` for better clarity and to accurately reflect its purpose.

## Linked Issues / Tickets

No references to specific tasks (maintenance/feedback).

- [] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review