### PR TITLE
feat: api adjustments - extension methods to use sdk easier

### DIFF
--- a/compat/bsm/sign.go
+++ b/compat/bsm/sign.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 
 	ec "github.com/bitcoin-sv/go-sdk/primitives/ec"
@@ -42,4 +43,14 @@ func SignMessageWithCompression(privateKey *ec.PrivateKey, message []byte, sigRe
 
 	// Sign
 	return ec.SignCompact(ec.S256(), privateKey, messageHash, sigRefCompressedKey)
+}
+
+// SignMessageString signs the message and returns the signature as a base64-encoded string
+func SignMessageString(privateKey *ec.PrivateKey, message []byte) (string, error) {
+	sigBytes, err := SignMessageWithCompression(privateKey, message, true)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(sigBytes), nil
 }

--- a/script/script.go
+++ b/script/script.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"math/bits"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ScriptKey types.
@@ -340,6 +342,31 @@ func MinPushSize(bb []byte) int {
 
 	// OP_PUSHDATA4 + four length bytes + data
 	return l + 5
+}
+
+// GetParts extracts the decoded chunks from the script.
+func (s *Script) GetParts() ([]*ScriptChunk, error) {
+	return DecodeScript([]byte(*s))
+}
+
+func (s *Script) GetPublicKey() (string, error) {
+	if !s.IsP2PK() {
+		return "", errors.New("script is not of type ScriptTypePubKey")
+	}
+
+	parts, err := s.GetParts()
+	if err != nil {
+		return "", err
+	}
+
+	if len(parts) == 0 || parts[0] == nil {
+		return "", errors.New("invalid script parts or missing public key part")
+	}
+
+	pubKey := parts[0].Data
+	pubKeyHex := hex.EncodeToString(pubKey)
+
+	return pubKeyHex, nil
 }
 
 // MarshalJSON convert script into json.

--- a/script/script.go
+++ b/script/script.go
@@ -349,6 +349,7 @@ func (s *Script) GetParts() ([]*ScriptChunk, error) {
 	return DecodeScript([]byte(*s))
 }
 
+// GetPublicKey extracts the public key from a P2PK script.
 func (s *Script) GetPublicKey() (string, error) {
 	if !s.IsP2PK() {
 		return "", errors.New("script is not of type ScriptTypePubKey")


### PR DESCRIPTION
This pull request introduces new functionalities and improvements to the `compat` and `script` packages, including new methods for signing messages and extracting script parts, as well as corresponding tests.

### New Functionalities:

* [`compat/bsm/sign.go`](diffhunk://#diff-4a65baa17e0c101f85c894ae161a3c1d3ada678e6b5b7f9db4aae77ab49ac4cfR47-R56): Added `SignMessageString` function to sign messages and return the signature as a base64-encoded string.
* [`script/script.go`](diffhunk://#diff-10e490e68d804f321bd5c9dc19a2df00cff712f43fea620c0fbd07dda8b6d019R347-R372): Added `GetParts` and `GetPublicKey` methods to the `Script` type for extracting decoded chunks and public keys from scripts.

### Code Improvements:

* [`compat/bsm/sign.go`](diffhunk://#diff-4a65baa17e0c101f85c894ae161a3c1d3ada678e6b5b7f9db4aae77ab49ac4cfR5): Imported `encoding/base64` package to support the new `SignMessageString` function.
* [`script/script.go`](diffhunk://#diff-10e490e68d804f321bd5c9dc19a2df00cff712f43fea620c0fbd07dda8b6d019R10-R11): Imported `github.com/pkg/errors` package for improved error handling.

### Tests:

* [`script/script_test.go`](diffhunk://#diff-0e8dbb055b5edef3d8cacd918071bc982189dfc594420cebf184856dcd075fccR568-R737): Added tests for `GetParts` and `GetPublicKey` methods, covering various scenarios including valid, invalid, and edge cases.

## Linked Issues / Tickets

No references to specific tasks (maintenance/feedback).


- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review