### PR TITLE
fix: bump order in BEEF creation

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -100,7 +100,7 @@ func (t *Transaction) BEEF() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	bumps := map[uint32]*MerklePath{}
+	bumps := []*MerklePath{}
 	bumpIndex := map[uint32]int{}
 	txns := map[string]*Transaction{t.TxID().String(): t}
 	ancestors, err := t.collectAncestors(txns)
@@ -112,11 +112,11 @@ func (t *Transaction) BEEF() ([]byte, error) {
 		if tx.MerklePath == nil {
 			continue
 		}
-		if _, ok := bumps[tx.MerklePath.BlockHeight]; !ok {
+		if _, ok := bumpIndex[tx.MerklePath.BlockHeight]; !ok {
 			bumpIndex[tx.MerklePath.BlockHeight] = len(bumps)
-			bumps[tx.MerklePath.BlockHeight] = tx.MerklePath
+			bumps = append(bumps, tx.MerklePath)
 		} else {
-			err := bumps[tx.MerklePath.BlockHeight].Combine(tx.MerklePath)
+			err := bumps[bumpIndex[tx.MerklePath.BlockHeight]].Combine(tx.MerklePath)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This implementation fixes a problem related to randomly writing BUMPs to the BEEF Hex
As stated in the documentation:
`When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next.`

This pull request includes changes to the `BEEF` method in the `transaction/beef.go` file to improve the handling of `MerklePath` objects. The most important changes include switching from a map to a slice for `bumps` and adjusting the logic to use the new data structure.

Improvements to `BEEF` method:

* Changed the `bumps` variable from a map to a slice of `*MerklePath` to simplify the data structure.
* Updated the logic to use `bumpIndex` for tracking indices in the `bumps` slice, replacing the previous map-based approach.