### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VERSION: '1.22'
-  GOLANGCI_LINT_VERSION: v1.61.0
+  GOLANGCI_LINT_VERSION: v1.62.2
 
 jobs:
   detect-modules:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GO_VERSION: '1.22'
-  GOLANGCI_LINT_VERSION: v1.61.0 
+  GOLANGCI_LINT_VERSION: v1.62.2
 
 jobs:
   sonarcloud:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,7 +109,7 @@ linters-settings:
   gci:
     # put imports beginning with prefix after 3rd-party packages;
     sections:
-      prefix(github.com/org/project)
+      - prefix(github.com/bitcoin-sv/go-sdk)
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
@@ -354,6 +354,7 @@ linters:
     - nestif
     - nlreturn
     - gci
+    - recvcheck
   disable-all: false
   presets:
     - bugs

--- a/chainhash/hash_test.go
+++ b/chainhash/hash_test.go
@@ -213,7 +213,7 @@ func TestMarshalling(t *testing.T) {
 
 	b, err := json.Marshal(myData)
 	require.NoError(t, err)
-	require.Equal(t, `{"hash":"24988b93623304735e42a71f5c1e161b9ee2b9c52a3be8260ea3b05fba4df22c"}`, string(b))
+	require.JSONEq(t, `{"hash":"24988b93623304735e42a71f5c1e161b9ee2b9c52a3be8260ea3b05fba4df22c"}`, string(b))
 
 	var myData2 test
 	err = json.Unmarshal(b, &myData2)

--- a/compat/base58/base58_test.go
+++ b/compat/base58/base58_test.go
@@ -1,0 +1,131 @@
+package compat
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestBase58(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		encoded string
+		err     bool
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			encoded: "",
+			err:     false,
+		},
+		{
+			name:    "single zero byte",
+			input:   "00",
+			encoded: "1",
+			err:     false,
+		},
+		{
+			name:    "decoded address",
+			input:   "00010966776006953D5567439E5E39F86A0D273BEED61967F6",
+			encoded: "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM",
+			err:     false,
+		},
+		{
+			name:    "decoded hash",
+			input:   "0123456789ABCDEF",
+			encoded: "C3CPq7c8PY",
+			err:     false,
+		},
+		{
+			name:    "leading zeros",
+			input:   "000000287FB4CD",
+			encoded: "111233QC4",
+			err:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test encoding
+			inputBytes, err := hex.DecodeString(tt.input)
+			if err != nil {
+				t.Fatalf("failed to decode hex input: %v", err)
+			}
+
+			encoded := Encode(inputBytes)
+			if encoded != tt.encoded {
+				t.Errorf("Encode() = %v, want %v", encoded, tt.encoded)
+			}
+
+			// Test decoding
+			decoded, err := Decode(tt.encoded)
+			if (err != nil) != tt.err {
+				t.Errorf("Decode() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+
+			if !tt.err && !bytes.Equal(decoded, inputBytes) {
+				t.Errorf("Decode() = %x, want %x", decoded, inputBytes)
+			}
+		})
+	}
+}
+
+func TestBase58DecodeInvalid(t *testing.T) {
+	invalidInputs := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "invalid character",
+			input: "invalid!@#$%",
+		},
+		{
+			name:  "mixed valid and invalid",
+			input: "1234!@#$%",
+		},
+	}
+
+	for _, tt := range invalidInputs {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Decode(tt.input)
+			if err == nil {
+				t.Error("Decode() expected error for invalid input")
+			}
+		})
+	}
+}
+
+func TestBase58EncodeEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			name:  "nil input",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "all zeros",
+			input: []byte{0, 0, 0, 0},
+			want:  "1111",
+		},
+		{
+			name:  "large number",
+			input: []byte{255, 255, 255, 255},
+			want:  "7YXq9G",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Encode(tt.input)
+			if got != tt.want {
+				t.Errorf("Encode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/script/interpreter/stack_test.go
+++ b/script/interpreter/stack_test.go
@@ -31,7 +31,7 @@ func tstCheckScriptError(gotErr, wantErr error) error {
 	// Ensure the want error type is a script error.
 	werr := &errs.Error{}
 	if ok := errors.As(wantErr, werr); !ok {
-		return fmt.Errorf("unexpected test error type %T", wantErr) //nolint:errorlint // test code
+		return fmt.Errorf("unexpected test error type %T", wantErr)
 	}
 
 	// Ensure the error codes match.  It's safe to use a raw type assert

--- a/transaction/broadcaster/woc.go
+++ b/transaction/broadcaster/woc.go
@@ -32,6 +32,13 @@ func (b *WhatsOnChain) Broadcast(t *transaction.Transaction) (
 	*transaction.BroadcastSuccess,
 	*transaction.BroadcastFailure,
 ) {
+	if t == nil {
+		return nil, &transaction.BroadcastFailure{
+			Code:        "500",
+			Description: "nil transaction",
+		}
+	}
+
 	if b.Client == nil {
 		b.Client = http.DefaultClient
 	}

--- a/transaction/merklepath_test.go
+++ b/transaction/merklepath_test.go
@@ -164,7 +164,7 @@ func TestMerklePathCombine(t *testing.T) {
 		require.NoError(t, err)
 		out, err := json.Marshal(BRC74JSON)
 		require.NoError(t, err)
-		require.Equal(t, string(out), BRC74JSONTrimmed)
+		require.JSONEq(t, BRC74JSONTrimmed, string(out))
 		root, err := BRC74JSON.ComputeRootHex(nil)
 		require.NoError(t, err)
 		require.Equal(t, root, BRC74Root)


### PR DESCRIPTION
- brings golangci-lint to the latest version
- improves test coverage for a couple files

This PR disables the `recvcheck` linter to allow mixed receiver types in the codebase. This is a pattern used in several types:

- `ByteString` in util/bytestring.go
- `VarInt` in transaction/varint.go
- `Flag` in script/interpreter/scriptflag/scriptflag.go
- `ParsedOpcode` in script/interpreter/opcodeparser.go
- `Hash` in chainhash/hash.go

The mixed receiver types (pointer and non-pointer) are benign