### PR TITLE
memory penalty for that allocation could be enormous

### DIFF
--- a/script/interpreter/opcodeparser.go
+++ b/script/interpreter/opcodeparser.go
@@ -135,7 +135,7 @@ func (o *ParsedOpcode) enforceMinimumDataPush() error {
 // Parse takes a *script.Script and returns a []interpreter.ParsedOp
 func (p *DefaultOpcodeParser) Parse(s *script.Script) (ParsedScript, error) {
 	scr := *s
-	parsedOps := make([]ParsedOpcode, 0, len(scr))
+	parsedOps := make([]ParsedOpcode, 0)
 	conditionalBlock := 0
 
 	for i := 0; i < len(scr); {


### PR DESCRIPTION
## Description of Changes

I tested for a transaction with the size of 66mb. Most of that is the script data. 

With the line `parsedOps := make([]ParsedOpcode, 0, len(scr))` we will be allocating `66,000,000 * sizeof(ParsedOpcode)` bytes. `ParsedOpcode` size is 64 bytes so that's why ARC was crashing here, it was trying to allocate 4.2GB memory.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment
- [ ] All tests pass when using `go test ./...`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review