### PR TITLE
Fix atomic beef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
-
-- [1.1.25 - 2025-05-09](#1124---2025-05-09)
-- [1.1.24 - 2025-04-24](#1123---2025-04-29)
+- [1.1.26 - 2025-05-14](#1126---2025-05-14)
+- [1.1.25 - 2025-05-09](#1125---2025-05-09)
+- [1.1.24 - 2025-04-24](#1124---2025-04-29)
 - [1.1.23 - 2025-04-23](#1123---2025-04-23)
 - [1.1.22 - 2025-03-14](#1122---2025-03-14)
 - [1.1.21 - 2025-03-12](#1121---2025-03-12)
@@ -31,6 +31,10 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.1 - 2024-08-28](#111---2024-08-28)
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
+
+## [1.1.26] - 2025-05-14
+  ### Updated
+  - Support AtomicBeef in NewBeefFromBytes
 
 ## [1.1.25] - 2025-05-09
   ### Fix

--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction/chaintracker"
@@ -122,10 +123,8 @@ func NewBeefFromBytes(beef []byte) (*Beef, error) {
 	}
 
 	if version == ATOMIC_BEEF {
-		txid := make([]byte, 32)
-		if _, err = reader.Read(txid); err != nil {
-			return nil, err
-		} else if version, err = readVersion(reader); err != nil {
+		reader.Seek(32, io.SeekCurrent)
+		if version, err = readVersion(reader); err != nil {
 			return nil, err
 		}
 	}

--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction/chaintracker"
@@ -116,17 +115,15 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[string]*BeefTx,
 }
 
 func NewBeefFromBytes(beef []byte) (*Beef, error) {
-	reader := bytes.NewReader(beef)
+	var reader *bytes.Reader
+	if binary.LittleEndian.Uint32(beef[:4]) == ATOMIC_BEEF {
+		reader = bytes.NewReader(beef[36:])
+	} else {
+		reader = bytes.NewReader(beef)
+	}
 	version, err := readVersion(reader)
 	if err != nil {
 		return nil, err
-	}
-
-	if version == ATOMIC_BEEF {
-		reader.Seek(32, io.SeekCurrent)
-		if version, err = readVersion(reader); err != nil {
-			return nil, err
-		}
 	}
 
 	if version == BEEF_V1 {

--- a/transaction/beef_test.go
+++ b/transaction/beef_test.go
@@ -96,9 +96,19 @@ func TestNewBEEFFromBytes(t *testing.T) {
 	require.Len(t, beef.BUMPs, 3, "BUMPs length does not match")
 	require.Len(t, beef.Transactions, 3, "Transactions length does not match")
 
+	tx := beef.FindTransaction("b1fc0f44ba629dbdffab9e34fcc4faf9dbde3560a7365c55c26fe4daab052aac")
+	require.NotNil(t, tx, "Transaction not found in BEEF data")
+
+	atomic, err := tx.AtomicBEEF(false)
+	require.NoError(t, err, "AtomicBEEF method failed")
+
+	_, err = NewTransactionFromBEEF(atomic)
+	require.NoError(t, err, "NewTransactionFromBEEF method failed")
+
 	binary.LittleEndian.PutUint32(beefBytes[0:4], 0xdeadbeef)
 	_, err = NewTransactionFromBEEF(beefBytes)
 	require.Error(t, err, "use NewBeefFromBytes to parse anything which isn't V1 BEEF or AtomicBEEF")
+
 }
 
 func TestBeefTransactionFinding(t *testing.T) {


### PR DESCRIPTION
## Description of Changes

Support Atomic in `NewBeefFromBytes`

Loosen validation to support rehydrating Beef exported with `allowPartial` 

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment
- [x] All tests pass when using `go test ./...`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review