### PR TITLE
remove ineffective code

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -719,7 +719,6 @@ func (b *Beef) MergeTxidOnly(txid string) *BeefTx {
 			KnownTxID:  knownTxID,
 		}
 		b.Transactions[txid] = tx
-		b.tryToValidateBumpIndex(tx)
 	}
 	return tx
 }
@@ -1034,10 +1033,10 @@ func (b *Beef) trimUnreferencedBumps() {
 
 	// Track which BUMP indices are still referenced by remaining transactions
 	usedBumpIndices := make(map[int]bool)
-	
+
 	// Build a set of transaction IDs that need BUMPs
 	txidsNeedingBumps := make(map[string]bool)
-	
+
 	for txid, tx := range b.Transactions {
 		switch tx.DataFormat {
 		case RawTxAndBumpIndex:


### PR DESCRIPTION
## Description of Changes

In relation to #153, it looks like `tryToValidateBumpIndex` simply sets `tx.Transaction.MerklePath = nil` if it isn't found in the beef. I don't know that I love the name of the method, but I think it should just be skipped in `MergeTxidOnly`

## Testing Procedure

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment
- [x] All tests pass when using `go test ./...`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review