### PR TITLE
[Fix] - Avoid logging sensitive key material in examples

### DIFF
--- a/docs/examples/create_wallet/create_wallet.go
+++ b/docs/examples/create_wallet/create_wallet.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"log"
 
@@ -79,7 +80,8 @@ func main() {
 
 	// Get the public key from the private key
 	publicKey := privateKey.PubKey()
-	fmt.Printf("Derived Public Key (Hex): %x\n", publicKey.Compressed())
+	publicKeyHash := sha256.Sum256(publicKey.Compressed())
+	fmt.Printf("Derived public key fingerprint: %x\n", publicKeyHash[:8])
 
 	// Get the P2PKH address from the public key
 	// This is one way to get the address.

--- a/docs/examples/generate_hd_key/README.md
+++ b/docs/examples/generate_hd_key/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to use the `bip32` compatibility package to genera
 The `generate_hd_key` example showcases:
 1. Calling `bip32.GenerateHDKeyPair` with a specified seed length (`bip32.SecureSeedLength`).
 2. Receiving the generated extended private key (xPriv) and extended public key (xPub).
-3. Printing both keys.
+3. Verifying the public key via a fingerprint without exposing key material.
 
 ## Code Walkthrough
 
@@ -21,9 +21,9 @@ if err != nil {
     log.Fatalf("Error generating HD key pair: %s", err.Error())
 }
 
-// Print the generated keys
-log.Printf("xPrivateKey: %s\n", xPrivateKey)
-log.Printf("xPublicKey: %s\n", xPublicKey)
+// Never log raw keys. Use a small fingerprint to confirm success.
+fingerprint := sha256.Sum256([]byte(xPublicKey))
+log.Printf("Generated HD key pair (xPriv length: %d, xPub fingerprint: %x)", len(xPrivateKey), fingerprint[:8])
 ```
 
 This section shows the direct use of `bip32.GenerateHDKeyPair`. This function creates a new master HD key from a randomly generated seed of the given length. It returns the extended private key (xPriv) and the corresponding extended public key (xPub) as strings.
@@ -35,11 +35,11 @@ To run this example:
 ```bash
 go run generate_hd_key.go
 ```
-The output will be the newly generated xPrivateKey and xPublicKey strings. Each run will produce a different key pair.
+The output will confirm the generated key lengths and show a short fingerprint of the xPub. Each run will produce a different key pair, so securely store the raw keys instead of logging them.
 
 **Note**:
-- The generated xPrivateKey is the master private key for an HD wallet structure. It should be kept extremely secure.
-- The xPublicKey can be used to derive child public keys without exposing the private key.
+- The generated xPrivateKey is the master private key for an HD wallet structure. It should be kept extremely secure and never logged in plaintext.
+- The xPublicKey can be used to derive child public keys without exposing the private key. Only expose fingerprints when confirming values in logs.
 - `bip32.SecureSeedLength` is typically 32 bytes (256 bits) or 64 bytes (512 bits) for strong security.
 
 ## Integration Steps

--- a/docs/examples/generate_hd_key/generate_hd_key.go
+++ b/docs/examples/generate_hd_key/generate_hd_key.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"log"
 
 	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
@@ -12,6 +13,8 @@ func main() {
 		log.Fatalf("error occurred: %s", err.Error())
 	}
 
-	// Success!
-	log.Printf("xPrivateKey: %s \n xPublicKey: %s", xPrivateKey, xPublicKey)
+	// Success! Avoid logging sensitive key material. Use a fingerprint of the public key
+	// for verification instead of printing the full keys.
+	publicKeyFingerprint := sha256.Sum256([]byte(xPublicKey))
+	log.Printf("Generated HD key pair (xPriv length: %d, xPub fingerprint: %x)", len(xPrivateKey), publicKeyFingerprint[:8])
 }


### PR DESCRIPTION
This pull request improves the security of the example code and documentation for wallet and HD key generation by avoiding the exposure of sensitive key material. Instead of printing or logging raw private or public keys, the code now logs only short fingerprints derived from the public keys. The documentation is updated to reflect these best practices.

**Security improvements in key handling:**

* In both `create_wallet.go` and `generate_hd_key.go`, added logic to compute and log only a fingerprint (first 8 bytes of a SHA-256 hash) of the public key or xPub, instead of printing the full key material. This reduces the risk of accidental key exposure. [[1]](diffhunk://#diff-33f95524697428efc560dc7314c69a5ddca3f2a01fbd76352b4dde98d955d4efL82-R84) [[2]](diffhunk://#diff-9f62b9d94b02050cb06b1c2e5fa4fc34fd3bfd698e19ff44aacd86483c2e7844L15-R19)

**Documentation updates:**

* Updated `generate_hd_key/README.md` to instruct users not to log raw keys, to use fingerprints for verification, and to clarify the importance of keeping private keys secure. The code walkthrough and output description were also revised to match the new fingerprinting approach. [[1]](diffhunk://#diff-a2c1e964be442376aea286a665fd5118d922100efecd4fabbbb631e214d6c2f5L10-R10) [[2]](diffhunk://#diff-a2c1e964be442376aea286a665fd5118d922100efecd4fabbbb631e214d6c2f5L24-R26) [[3]](diffhunk://#diff-a2c1e964be442376aea286a665fd5118d922100efecd4fabbbb631e214d6c2f5L38-R42)

**Dependency additions:**

* Added the `crypto/sha256` import to both example files to support fingerprint generation. [[1]](diffhunk://#diff-33f95524697428efc560dc7314c69a5ddca3f2a01fbd76352b4dde98d955d4efR4) [[2]](diffhunk://#diff-9f62b9d94b02050cb06b1c2e5fa4fc34fd3bfd698e19ff44aacd86483c2e7844R4)