### PR TITLE
[Fix] - Avoid logging sensitive derivation details

### DIFF
--- a/docs/examples/create_wallet/create_wallet.go
+++ b/docs/examples/create_wallet/create_wallet.go
@@ -68,7 +68,7 @@ func main() {
 	// The DeriveChildFromPath method handles string paths.
 	derivedKey, err := masterKey.DeriveChildFromPath(derivationPathStr)
 	if err != nil {
-		log.Fatalf("Failed to derive key for path %s: %v", derivationPathStr, err)
+		log.Fatal("Failed to derive key for requested path; aborting to protect sensitive data")
 	}
 
 	// Get the private key from the derived extended key


### PR DESCRIPTION
This pull request makes a small change to the error handling in the `create_wallet.go` example. The error message when failing to derive a child key from a path has been updated to avoid leaking sensitive information.