### PR TITLE
Fix SPV fee rejection logic and performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Table of Contents
 
+- [1.2.15 - 2026-01-27](#1215---2026-01-27)
 - [1.2.14 - 2025-12-19](#1214---2025-12-19)
 - [1.2.13 - 2025-12-05](#1213---2025-12-05)
 - [1.2.12 - 2025-11-12](#1212---2025-11-12)
@@ -48,6 +49,21 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.1 - 2024-08-28](#111---2024-08-28)
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
+
+## [1.2.15] - 2026-01-27
+
+### Fixed
+- SPV fee validation now only validates fees on the root transaction, not ancestor transactions in the BEEF chain. Previously, historical ancestors with different fee rates could incorrectly fail validation.
+
+### Added
+- `VarInt.PutBytes()` method for direct buffer writing without allocation
+- `Beef.MergeTransactionWithTxid()` and `Beef.MergeBeefTxWithTxid()` methods to merge transactions without recomputing TxID
+- Test coverage for `VarInt.PutBytes()` method
+
+### Changed
+- Optimized `Transaction.Bytes()`, `Input.Bytes()`, and `Output.Bytes()` methods with pre-calculated size and pre-allocated buffers
+- Optimized BEEF serialization with pre-allocated buffers
+- `LookupFormula.History` now uses `*Beef` type instead of `[]byte`
 
 ## [1.2.14] - 2025-12-19
 

--- a/overlay/lookup/types.go
+++ b/overlay/lookup/types.go
@@ -29,7 +29,7 @@ type LookupQuestion struct {
 // LookupFormula represents a formula for computing lookup results
 type LookupFormula struct {
 	Outpoint *transaction.Outpoint
-	History  func(beef []byte, outputIndex uint32, currentDepth uint32) bool
+	History  func(beef *transaction.Beef, outputIndex uint32, currentDepth uint32) bool
 	// HistoryDepth uint32
 }
 

--- a/spv/verify.go
+++ b/spv/verify.go
@@ -48,10 +48,10 @@ func Verify(ctx context.Context, t *transaction.Transaction,
 			tx.TotalOutputSatoshis()
 			if txFee, err := tx.GetFee(); err != nil {
 				return false, err
-			} else if cloneFee, err := clone.GetFee(); err != nil {
+			} else if requiredFee, err := clone.GetFee(); err != nil {
 				return false, err
-			} else if cloneFee < txFee {
-				return false, fmt.Errorf("fee is too low")
+			} else if txFee < requiredFee {
+				return false, fmt.Errorf("fee is too low: paid %d, required %d", txFee, requiredFee)
 			}
 		}
 

--- a/spv/verify_test.go
+++ b/spv/verify_test.go
@@ -53,7 +53,7 @@ func TestSPVVerifyWithInsufficientFee(t *testing.T) {
 	require.NoError(t, err)
 
 	feeModel := &feemodel.SatoshisPerKilobyte{
-		Satoshis: 1,
+		Satoshis: 100,
 	}
 
 	ctx := t.Context()

--- a/transaction/output.go
+++ b/transaction/output.go
@@ -77,13 +77,15 @@ script:    %s
 
 // Bytes encodes the Output into a byte array.
 func (o *TransactionOutput) Bytes() []byte {
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, o.Satoshis)
+	scriptLen := len(*o.LockingScript)
+	varInt := util.VarInt(uint64(scriptLen))
+	varIntLen := varInt.Length()
+	totalLen := 8 + varIntLen + scriptLen
 
-	h := make([]byte, 0)
-	h = append(h, b...)
-	h = append(h, util.VarInt(uint64(len(*o.LockingScript))).Bytes()...)
-	h = append(h, *o.LockingScript...)
+	h := make([]byte, totalLen)
+	binary.LittleEndian.PutUint64(h[0:8], o.Satoshis)
+	varInt.PutBytes(h[8:])
+	copy(h[8+varIntLen:], *o.LockingScript)
 
 	return h
 }

--- a/util/varint.go
+++ b/util/varint.go
@@ -103,6 +103,28 @@ func (v *VarInt) ReadFrom(r io.Reader) (int64, error) {
 	}
 }
 
+// PutBytes writes the VarInt to the destination buffer and returns the number of bytes written.
+// The destination buffer must be at least Length() bytes long.
+func (v VarInt) PutBytes(dst []byte) int {
+	if v < 0xfd {
+		dst[0] = byte(v)
+		return 1
+	}
+	if v < 0x10000 {
+		dst[0] = 0xfd
+		binary.LittleEndian.PutUint16(dst[1:3], uint16(v))
+		return 3
+	}
+	if v < 0x100000000 {
+		dst[0] = 0xfe
+		binary.LittleEndian.PutUint32(dst[1:5], uint32(v))
+		return 5
+	}
+	dst[0] = 0xff
+	binary.LittleEndian.PutUint64(dst[1:9], uint64(v))
+	return 9
+}
+
 // UpperLimitInc returns true if a number is at the
 // upper limit of a VarInt and will result in a VarInt
 // length change if incremented. The value returned will


### PR DESCRIPTION
## Summary
- Fix SPV fee verification logic - comparison was inverted (`cloneFee < txFee` → `txFee < requiredFee`)
- Fix insufficient fee test to use standard 100 sat/kb rate
- Optimize BEEF/transaction serialization with pre-allocated buffers instead of append
- Add `MergeTransactionWithTxid` and `MergeBeefTxWithTxid` to avoid recomputing TxID when already known
- Add `VarInt.PutBytes()` for direct buffer writing
- Update `LookupFormula.History` signature to use `*Beef` type instead of `[]byte`

## Test plan
- [x] All existing tests pass
- [x] SPV fee verification tests pass with corrected logic
- [x] `go vet` passes (pre-existing warnings on master unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)