### PR TITLE
Close results channel before iterating

### DIFF
--- a/overlay/topic/broadcaster.go
+++ b/overlay/topic/broadcaster.go
@@ -159,6 +159,7 @@ func (b *Broadcaster) BroadcastCtx(ctx context.Context, tx *transaction.Transact
 	wg.Wait()
 
 	successfulHosts := make([]*Response, 0, len(interestedHosts))
+	close(results) // CHANGE. Must close results channel before ranging. Will cause broadcast() to hang indefinitely.
 	for result := range results {
 		if result != nil {
 			successfulHosts = append(successfulHosts, result)


### PR DESCRIPTION
Ensure results channel is closed before ranging to prevent hang.

## Description of Changes

Added close(results) so function returns

## Linked Issues / Tickets

Issue #293

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [X] All tests pass locally
- [X] I have tested manually in my local environment
- [X] All tests pass when using `go test ./...`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I ran `golangci-lint run`
- [X] I have run `go fmt` and `go vet` one final time before requesting a review