### PR TITLE
feat: add reference to internalize action

### DIFF
--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -434,6 +434,7 @@ type InternalizeActionArgs struct {
 	Labels         []string            `json:"labels"`
 	SeekPermission *bool               `json:"seekPermission,omitempty"`
 	Outputs        []InternalizeOutput `json:"outputs"`
+	Reference      *string             `json:"reference,omitempty"`
 }
 
 // InternalizeActionResult confirms whether a transaction was successfully internalized.

--- a/wallet/serializer/internalize_action.go
+++ b/wallet/serializer/internalize_action.go
@@ -50,6 +50,11 @@ func SerializeInternalizeActionArgs(args *wallet.InternalizeActionArgs) ([]byte,
 	w.WriteString(args.Description)
 	w.WriteOptionalBool(args.SeekPermission)
 
+	// Serialize reference (only if non-nil for backward ts compatibility)
+	if args.Reference != nil {
+		w.WriteOptionalString(*args.Reference)
+	}
+
 	return w.Buf, nil
 }
 
@@ -108,6 +113,14 @@ func DeserializeInternalizeActionArgs(data []byte) (*wallet.InternalizeActionArg
 	args.Labels = r.ReadStringSlice()
 	args.Description = r.ReadString()
 	args.SeekPermission = r.ReadOptionalBool()
+
+	// Deserialize reference (optional - only if data is available for backward ts compatibility)
+	if !r.IsComplete() {
+		ref := r.ReadOptionalString()
+		if ref != "" {
+			args.Reference = &ref
+		}
+	}
 
 	r.CheckComplete()
 	if r.Err != nil {

--- a/wallet/serializer/internalize_action_test.go
+++ b/wallet/serializer/internalize_action_test.go
@@ -1,17 +1,19 @@
 package serializer
 
 import (
+	"testing"
+
 	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/go-sdk/util"
 	"github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestInternalizeActionArgs(t *testing.T) {
 	pk, err := ec.NewPrivateKey()
 	require.NoError(t, err, "creating new private key should not error")
 	senderKey := pk.PubKey()
+	testRef := "test-reference-123"
 	tests := []struct {
 		name string
 		args *wallet.InternalizeActionArgs
@@ -42,6 +44,26 @@ func TestInternalizeActionArgs(t *testing.T) {
 			Description:    "test description",
 			Labels:         []string{"label1", "label2"},
 			SeekPermission: util.BoolPtr(true),
+		},
+	}, {
+		name: "full args with reference",
+		args: &wallet.InternalizeActionArgs{
+			Tx: []byte{1, 2, 3, 4},
+			Outputs: []wallet.InternalizeOutput{
+				{
+					OutputIndex: 0,
+					Protocol:    wallet.InternalizeProtocolWalletPayment,
+					PaymentRemittance: &wallet.Payment{
+						DerivationPrefix:  []byte("prefix"),
+						DerivationSuffix:  []byte("suffix"),
+						SenderIdentityKey: senderKey,
+					},
+				},
+			},
+			Description:    "test description with reference",
+			Labels:         []string{"label1"},
+			SeekPermission: util.BoolPtr(true),
+			Reference:      &testRef,
 		},
 	}, {
 		name: "minimal args",


### PR DESCRIPTION
## Description of Changes

Add reference to InternalizeActionArgs which allow to add custom reference during internalizing transaction. This Pr is connected with changes in #289 

This changes are used in go-wallet-toolbox PR: [#763
](https://github.com/bsv-blockchain/go-wallet-toolbox/pull/763)
## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment
- [ ] All tests pass when using `go test ./...`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review