### PR TITLE
fix: overlay broadcaster

### DIFF
--- a/overlay/lookup/resolver.go
+++ b/overlay/lookup/resolver.go
@@ -17,7 +17,14 @@ import (
 
 const MAX_TRACKER_WAIT_TIME = time.Second
 
-var DEFAULT_SLAP_TRACKERS = []string{"https://users.bapp.dev"}
+var DEFAULT_SLAP_TRACKERS = []string{
+	// BSVA clusters
+	"https://overlay-us-1.bsvb.tech",
+	"https://overlay-eu-1.bsvb.tech",
+	"https://overlay-ap-1.bsvb.tech",
+	// Babbage primary overlay service
+	"https://users.bapp.dev",
+}
 var DEFAULT_TESTNET_SLAP_TRACKERS = []string{"https://testnet-users.bapp.dev"}
 
 // LookupResolver resolves overlay service hosts and executes lookup queries with resiliency across multiple services

--- a/overlay/topic/broadcaster.go
+++ b/overlay/topic/broadcaster.go
@@ -157,10 +157,11 @@ func (b *Broadcaster) BroadcastCtx(ctx context.Context, tx *transaction.Transact
 		}(host)
 	}
 	wg.Wait()
+	close(results)
 
 	successfulHosts := make([]*Response, 0, len(interestedHosts))
 	for result := range results {
-		if result != nil {
+		if result != nil && result.Success {
 			successfulHosts = append(successfulHosts, result)
 		}
 	}
@@ -190,9 +191,12 @@ func (b *Broadcaster) BroadcastCtx(ctx context.Context, tx *transaction.Transact
 	case RequireAckSome:
 		requireTopics = b.AckFromAll.Topics
 		requireHosts = RequireAckAll
-	default:
+	case RequireAckAll:
 		requireTopics = b.Topics
 		requireHosts = RequireAckAll
+	default:
+		requireTopics = []string{}
+		requireHosts = RequireAckNone
 	}
 	if len(requireTopics) > 0 {
 		if !b.checkAcknowledgmentFromAllHosts(hostAcks, requireTopics, requireHosts) {
@@ -210,9 +214,12 @@ func (b *Broadcaster) BroadcastCtx(ctx context.Context, tx *transaction.Transact
 	case RequireAckSome:
 		requireTopics = b.AckFromAny.Topics
 		requireHosts = RequireAckAll
-	default:
+	case RequireAckAll:
 		requireTopics = b.Topics
 		requireHosts = RequireAckAll
+	default:
+		requireTopics = []string{}
+		requireHosts = RequireAckNone
 	}
 	if len(requireTopics) > 0 {
 		if !b.checkAcknowledgmentFromAnyHost(hostAcks, requireTopics, requireHosts) {

--- a/overlay/topic/facilitator.go
+++ b/overlay/topic/facilitator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bsv-blockchain/go-sdk/util"
 )
 
-const MAX_SHIP_QUERY_TIMEOUT = time.Second
+const MAX_SHIP_QUERY_TIMEOUT = 5 * time.Second
 
 // Facilitator defines the interface for overlay broadcast facilitators that can send tagged BEEF to overlay services
 type Facilitator interface {


### PR DESCRIPTION
## Description of Changes

This PR improves the resiliency of the Overlay Service host discovery process in the go-sdk. It aligns the default SLAP tracker configuration and query timeouts with the @bsv/sdk (TypeScript) implementation. 

Fixes:
- Distinction between `RequireAckAll` and `RequireNone` (based on TS version and empty topic array)
- Improved the broadcast flow to strictly separate successful responses from errors before processing admittance. Previously, error responses could trigger admittance checks, now we only evaluate result from hosts that returned a 200 OK.
- Increased default SHIP query timeout, before at 1 second there was no successful response (only `error="context deadline exceeded"`), 5s allows to get at least one success response
- Added the three BSVA cluster SLAP trackers (overlay-us-1.bsvb.tech, etc.) as defaults. This moves away from a single point of failure and matches the redundancy provided in the TS SDK.


## Testing Procedure

This issues was found when working on `go-uhrp-storage-server`