### PR TITLE
Implement BSV Chronicle Op Code Fidelity Pass & Compound Merkle Path Assurances

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -47,7 +47,7 @@ jobs:
           args: --timeout=5m --issues-exit-code=0 --output.checkstyle.path=golangci-lint-report.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v7.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -47,7 +47,7 @@ jobs:
           args: --timeout=5m --issues-exit-code=0 --output.checkstyle.path=golangci-lint-report.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7.0.0
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/script/interpreter/chronicle_opcodes_test.go
+++ b/script/interpreter/chronicle_opcodes_test.go
@@ -255,9 +255,6 @@ func TestChronicleOpcodesPostChronicle(t *testing.T) {
 	hello := []byte("Hello")
 	world := []byte("World")
 
-	// verTx is a version-1 transaction; OP_VER / VERIF / VERNOTIF all read t.tx.Version.
-	verTx := chronicleVersionTx(1)
-
 	tests := []struct {
 		name      string
 		locking   func() *script.Script
@@ -393,7 +390,7 @@ func TestChronicleOpcodesPostChronicle(t *testing.T) {
 			if tc.needTx {
 				prevOut := &transaction.TransactionOutput{LockingScript: locking}
 				opts = []ExecutionOptionFunc{
-					WithTx(verTx, 0, prevOut),
+					WithTx(chronicleVersionTx(1), 0, prevOut),
 					WithAfterChronicle(),
 				}
 			} else {

--- a/script/interpreter/chronicle_opcodes_test.go
+++ b/script/interpreter/chronicle_opcodes_test.go
@@ -1,0 +1,611 @@
+// Copyright (c) 2024 The bsv-blockchain/go-sdk developers
+// Use of this source code is governed by an ISC license that can be found in the LICENSE file.
+
+// Tests derived from the BSV node v1.2.0 Chronicle upgrade functional tests:
+// https://github.com/bitcoin-sv/bitcoin-sv/tree/172c8fa38cce30cf4df0327b33c7418ea6289de8/test/functional/chronicle_upgrade_tests
+
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter/errs"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter/scriptflag"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+// buildScript constructs a *script.Script from push-data + opcode sequences.
+// Each element is either a []byte (pushed as data) or a byte (appended as opcode).
+func buildScript(t *testing.T, parts ...interface{}) *script.Script {
+	t.Helper()
+	s := &script.Script{}
+	for _, p := range parts {
+		switch v := p.(type) {
+		case byte:
+			require.NoError(t, s.AppendOpcodes(v))
+		case []byte:
+			require.NoError(t, s.AppendPushData(v))
+		default:
+			t.Fatalf("buildScript: unsupported element type %T", p)
+		}
+	}
+	return s
+}
+
+// chronicleVersionTx returns a minimal transaction with the given version number.
+// It is used for opcodes that read t.tx.Version (OP_VER, OP_VERIF, OP_VERNOTIF).
+func chronicleVersionTx(ver uint32) *transaction.Transaction {
+	s := script.Script{}
+	return &transaction.Transaction{
+		Version: ver,
+		Inputs: []*transaction.TransactionInput{{
+			SourceTxOutIndex: 0,
+			UnlockingScript:  &s,
+			SequenceNumber:   0xffffffff,
+		}},
+		Outputs: []*transaction.TransactionOutput{{
+			Satoshis: 0,
+		}},
+	}
+}
+
+// versionLE serialises a uint32 as 4-byte little-endian – the format OP_VER pushes.
+func versionLE(v uint32) []byte {
+	return []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
+}
+
+// TestChronicleOpcodes_PreChronicle verifies that every Chronicle-reactivated opcode
+// is rejected with the correct error when executed in the pre-Chronicle era.
+// Mirrors the PRE_CHRONICLE phase in opcodes.py.
+func TestChronicleOpcodes_PreChronicle(t *testing.T) {
+	t.Parallel()
+
+	helloWorld := []byte("HelloWorld")
+	oWorl := []byte("oWorl")
+	hello := []byte("Hello")
+	world := []byte("World")
+
+	tests := []struct {
+		name       string
+		locking    func() *script.Script
+		unlocking  *script.Script
+		wantErrCode errs.ErrorCode
+		flags      scriptflag.Flag
+		needTx     bool // set true when the opcode reads t.tx
+	}{
+		// OP_VER (0x62) – reserved pre-Chronicle
+		{
+			name: "OP_VER OP_DROP OP_TRUE rejected pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.OpVER, script.OpDROP, script.Op1)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrReservedOpcode,
+			needTx:      true,
+		},
+		// OP_VERIF (0x65) – always-illegal pre-Chronicle
+		{
+			name: "OP_VERIF always-illegal pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					versionLE(1),
+					script.OpVERIF,
+					script.Op1,
+					script.OpELSE,
+					script.Op0,
+					script.OpENDIF,
+				)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrReservedOpcode,
+			needTx:      true,
+		},
+		// OP_VERNOTIF (0x66) – always-illegal pre-Chronicle
+		{
+			name: "OP_VERNOTIF always-illegal pre-Chronicle",
+			locking: func() *script.Script {
+				// 0x01ff0000 != version 1, so VERNOTIF branch would be true post-Chronicle
+				return buildScript(t,
+					versionLE(0x0000ff01),
+					script.OpVERNOTIF,
+					script.Op1,
+					script.OpELSE,
+					script.Op0,
+					script.OpENDIF,
+				)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrReservedOpcode,
+			needTx:      true,
+		},
+		// OP_SUBSTR (0xb3) – NOP4 pre-Chronicle; DiscourageUpgradableNops → error
+		{
+			name: "OP_SUBSTR treated as NOP4 pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op4,
+					script.Op5,
+					script.OpSUBSTR,
+					oWorl,
+					script.OpEQUAL,
+				)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDiscourageUpgradableNOPs,
+			flags:       scriptflag.DiscourageUpgradableNops,
+		},
+		// OP_LEFT (0xb4) – NOP5 pre-Chronicle
+		{
+			name: "OP_LEFT treated as NOP5 pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op5,
+					script.OpLEFT,
+					hello,
+					script.OpEQUAL,
+				)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDiscourageUpgradableNOPs,
+			flags:       scriptflag.DiscourageUpgradableNops,
+		},
+		// OP_RIGHT (0xb5) – NOP6 pre-Chronicle
+		{
+			name: "OP_RIGHT treated as NOP6 pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op5,
+					script.OpRIGHT,
+					world,
+					script.OpEQUAL,
+				)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDiscourageUpgradableNOPs,
+			flags:       scriptflag.DiscourageUpgradableNops,
+		},
+		// OP_2MUL (0x8d) – disabled pre-Chronicle
+		{
+			name: "OP_2MUL disabled pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op1, script.Op2MUL, script.Op2, script.OpEQUAL)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDisabledOpcode,
+		},
+		// OP_2DIV (0x8e) – disabled pre-Chronicle
+		{
+			name: "OP_2DIV disabled pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op2, script.Op2DIV, script.Op1, script.OpEQUAL)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDisabledOpcode,
+		},
+		// OP_LSHIFTNUM (0xb6) – NOP7 pre-Chronicle
+		{
+			name: "OP_LSHIFTNUM treated as NOP7 pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op1, script.Op2, script.OpLSHIFTNUM, script.Op4, script.OpEQUAL)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDiscourageUpgradableNOPs,
+			flags:       scriptflag.DiscourageUpgradableNops,
+		},
+		// OP_RSHIFTNUM (0xb7) – NOP8 pre-Chronicle
+		{
+			name: "OP_RSHIFTNUM treated as NOP8 pre-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op16, script.Op2, script.OpRSHIFTNUM, script.Op4, script.OpEQUAL)
+			},
+			unlocking:   &script.Script{},
+			wantErrCode: errs.ErrDiscourageUpgradableNOPs,
+			flags:       scriptflag.DiscourageUpgradableNops,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			locking := tc.locking()
+			opts := []ExecutionOptionFunc{
+				WithScripts(locking, tc.unlocking),
+				WithAfterGenesis(),
+			}
+			if tc.flags != 0 {
+				opts = append(opts, WithFlags(tc.flags))
+			}
+			if tc.needTx {
+				tx := chronicleVersionTx(1)
+				prevOut := &transaction.TransactionOutput{LockingScript: locking}
+				opts = []ExecutionOptionFunc{
+					WithTx(tx, 0, prevOut),
+					WithAfterGenesis(),
+				}
+				if tc.flags != 0 {
+					opts = append(opts, WithFlags(tc.flags))
+				}
+			}
+
+			err := NewEngine().Execute(opts...)
+			require.Error(t, err)
+			var scriptErr errs.Error
+			require.ErrorAs(t, err, &scriptErr)
+			require.Equal(t, tc.wantErrCode, scriptErr.ErrorCode,
+				"expected error code %s got %s", tc.wantErrCode, scriptErr.ErrorCode)
+		})
+	}
+}
+
+// TestChronicleOpcodes_PostChronicle verifies that every Chronicle-reactivated opcode
+// executes correctly in the post-Chronicle era.
+// Mirrors the POST_CHRONICLE phase in opcodes.py.
+func TestChronicleOpcodes_PostChronicle(t *testing.T) {
+	t.Parallel()
+
+	helloWorld := []byte("HelloWorld")
+	oWorl := []byte("oWorl")
+	hello := []byte("Hello")
+	world := []byte("World")
+
+	// verTx is a version-1 transaction; OP_VER / VERIF / VERNOTIF all read t.tx.Version.
+	verTx := chronicleVersionTx(1)
+
+	tests := []struct {
+		name      string
+		locking   func() *script.Script
+		unlocking *script.Script
+		needTx    bool
+	}{
+		// OP_VER pushes tx version (1 → 01 00 00 00), OP_DROP, OP_TRUE → succeeds
+		{
+			name: "OP_VER pushes version, OP_DROP, OP_TRUE succeeds post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.OpVER, script.OpDROP, script.Op1)
+			},
+			unlocking: &script.Script{},
+			needTx:    true,
+		},
+		// OP_VERIF with matching version: conditional true branch → OP_TRUE
+		{
+			name: "OP_VERIF version-conditional true branch post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					versionLE(1), // push 01 00 00 00 (version 1 LE)
+					script.OpVERIF,
+					script.Op1,
+					script.OpELSE,
+					script.Op0,
+					script.OpENDIF,
+				)
+			},
+			unlocking: &script.Script{},
+			needTx:    true,
+		},
+		// OP_VERNOTIF with non-matching version: NOTIF branch (true when not equal) → OP_TRUE
+		{
+			name: "OP_VERNOTIF version-conditional (not-equal branch) post-Chronicle",
+			locking: func() *script.Script {
+				// 0x0000ff01 ≠ version 1 (0x00000001), so VERNOTIF takes the true branch
+				return buildScript(t,
+					versionLE(0x0000ff01),
+					script.OpVERNOTIF,
+					script.Op1,
+					script.OpELSE,
+					script.Op0,
+					script.OpENDIF,
+				)
+			},
+			unlocking: &script.Script{},
+			needTx:    true,
+		},
+		// OP_SUBSTR("HelloWorld", 4, 5) == "oWorl"
+		{
+			name: "OP_SUBSTR extracts substring post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op4,
+					script.Op5,
+					script.OpSUBSTR,
+					oWorl,
+					script.OpEQUAL,
+				)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_LEFT("HelloWorld", 5) == "Hello"
+		{
+			name: "OP_LEFT returns left N bytes post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op5,
+					script.OpLEFT,
+					hello,
+					script.OpEQUAL,
+				)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_RIGHT("HelloWorld", 5) == "World"
+		{
+			name: "OP_RIGHT returns right N bytes post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t,
+					helloWorld,
+					script.Op5,
+					script.OpRIGHT,
+					world,
+					script.OpEQUAL,
+				)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_2MUL: 1 * 2 == 2
+		{
+			name: "OP_2MUL multiplies by 2 post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op1, script.Op2MUL, script.Op2, script.OpEQUAL)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_2DIV: 2 / 2 == 1
+		{
+			name: "OP_2DIV divides by 2 post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op2, script.Op2DIV, script.Op1, script.OpEQUAL)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_LSHIFTNUM: 1 << 2 == 4
+		{
+			name: "OP_LSHIFTNUM left-shifts by N post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op1, script.Op2, script.OpLSHIFTNUM, script.Op4, script.OpEQUAL)
+			},
+			unlocking: &script.Script{},
+		},
+		// OP_RSHIFTNUM: 16 >> 2 == 4
+		{
+			name: "OP_RSHIFTNUM right-shifts by N post-Chronicle",
+			locking: func() *script.Script {
+				return buildScript(t, script.Op16, script.Op2, script.OpRSHIFTNUM, script.Op4, script.OpEQUAL)
+			},
+			unlocking: &script.Script{},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			locking := tc.locking()
+			var opts []ExecutionOptionFunc
+			if tc.needTx {
+				prevOut := &transaction.TransactionOutput{LockingScript: locking}
+				opts = []ExecutionOptionFunc{
+					WithTx(verTx, 0, prevOut),
+					WithAfterChronicle(),
+				}
+			} else {
+				opts = []ExecutionOptionFunc{
+					WithScripts(locking, tc.unlocking),
+					WithAfterChronicle(),
+				}
+			}
+
+			err := NewEngine().Execute(opts...)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestChronicleOpcodes_EdgeCases covers boundary conditions for Chronicle opcodes.
+func TestChronicleOpcodes_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OP_VER without tx returns error post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		locking := buildScript(t, script.OpVER, script.Op1)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("OP_SUBSTR invalid range rejected post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// "Hi" has length 2; requesting begin=5, len=1 is out of range
+		locking := buildScript(t,
+			[]byte("Hi"),
+			script.Op5,
+			script.Op1,
+			script.OpSUBSTR,
+			script.Op1, // bogus expected
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("OP_LEFT zero bytes post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// OP_LEFT("Hello", 0) == ""
+		locking := buildScript(t,
+			[]byte("Hello"),
+			script.Op0,
+			script.OpLEFT,
+			[]byte{}, // push empty
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_RIGHT full-length post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// OP_RIGHT("Hello", 5) == "Hello" (all bytes)
+		locking := buildScript(t,
+			[]byte("Hello"),
+			script.Op5,
+			script.OpRIGHT,
+			[]byte("Hello"),
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_LSHIFTNUM zero shift is identity post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// 7 << 0 == 7
+		locking := buildScript(t,
+			script.Op7,
+			script.Op0,
+			script.OpLSHIFTNUM,
+			script.Op7,
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_RSHIFTNUM to zero post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// 1 >> 8 == 0
+		locking := buildScript(t,
+			script.Op1,
+			script.Op8,
+			script.OpRSHIFTNUM,
+			script.Op0,
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_2MUL zero post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// 0 * 2 == 0
+		locking := buildScript(t,
+			script.Op0,
+			script.Op2MUL,
+			script.Op0,
+			script.OpEQUAL,
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_VERIF non-matching version takes else branch post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// Push version 2 bytes; tx is version 1 → not equal → VERIF goes to ELSE → OP_TRUE
+		locking := buildScript(t,
+			versionLE(2), // 02 00 00 00
+			script.OpVERIF,
+			script.Op0,  // true branch (NOT taken since versions differ)
+			script.OpELSE,
+			script.Op1,  // false branch (taken)
+			script.OpENDIF,
+		)
+		tx := chronicleVersionTx(1)
+		prevOut := &transaction.TransactionOutput{LockingScript: locking}
+		err := NewEngine().Execute(
+			WithTx(tx, 0, prevOut),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("OP_VERNOTIF matching version takes else branch post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		// Push version 1 bytes; tx is version 1 → equal → VERNOTIF (not-if) goes to ELSE → OP_TRUE
+		locking := buildScript(t,
+			versionLE(1), // 01 00 00 00
+			script.OpVERNOTIF,
+			script.Op0, // true branch (NOT taken since they are equal)
+			script.OpELSE,
+			script.Op1, // false branch (taken because VERNOTIF condition is "not equal")
+			script.OpENDIF,
+		)
+		tx := chronicleVersionTx(1)
+		prevOut := &transaction.TransactionOutput{LockingScript: locking}
+		err := NewEngine().Execute(
+			WithTx(tx, 0, prevOut),
+			WithAfterChronicle(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("MaxScriptNumberLength is 32MB post-Chronicle", func(t *testing.T) {
+		t.Parallel()
+		cfg := &afterChronicleConfig{}
+		require.Equal(t, MaxScriptNumberLengthAfterChronicle, cfg.MaxScriptNumberLength())
+		require.Equal(t, 32*1024*1024, cfg.MaxScriptNumberLength())
+	})
+
+	t.Run("afterChronicleConfig implies afterGenesis", func(t *testing.T) {
+		t.Parallel()
+		cfg := &afterChronicleConfig{}
+		require.True(t, cfg.AfterGenesis())
+		require.True(t, cfg.AfterChronicle())
+	})
+}
+
+// TestChronicleNopBehavior_WithoutDiscourageFlag verifies that the Chronicle NOP-type
+// opcodes (SUBSTR/LEFT/RIGHT/LSHIFTNUM/RSHIFTNUM) are silent NOPs pre-Chronicle when
+// the DiscourageUpgradableNops flag is absent, leaving extra items on the stack.
+func TestChronicleNopBehavior_WithoutDiscourageFlag(t *testing.T) {
+	t.Parallel()
+
+	// Pre-Chronicle: OP_SUBSTR is a NOP, so stack ends up with extra items.
+	// Script: "AB" OP_1 OP_1 OP_SUBSTR "AB" OP_EQUAL
+	// Stack after NOP:  ["AB", 1, 1, "AB"] → EQUAL pops "AB"==1 → false
+	// Top of stack is false → ErrEvalFalse (or the equal gives false)
+	t.Run("OP_SUBSTR as silent NOP leaves extra stack items", func(t *testing.T) {
+		t.Parallel()
+		locking := buildScript(t,
+			[]byte("AB"),
+			script.Op1,
+			script.Op1,
+			script.OpSUBSTR, // NOP, does nothing
+			[]byte("AB"),    // pushed on top
+			script.OpEQUAL, // "AB" == 1? → false, leaves extra ["AB",1,false]
+		)
+		err := NewEngine().Execute(
+			WithScripts(locking, &script.Script{}),
+			WithAfterGenesis(),
+			// no DiscourageUpgradableNops
+		)
+		// Script ends with false top of stack (or false-equal) – must fail
+		require.Error(t, err)
+	})
+}

--- a/script/interpreter/chronicle_opcodes_test.go
+++ b/script/interpreter/chronicle_opcodes_test.go
@@ -59,7 +59,7 @@ func versionLE(v uint32) []byte {
 // TestChronicleOpcodes_PreChronicle verifies that every Chronicle-reactivated opcode
 // is rejected with the correct error when executed in the pre-Chronicle era.
 // Mirrors the PRE_CHRONICLE phase in opcodes.py.
-func TestChronicleOpcodes_PreChronicle(t *testing.T) {
+func TestChronicleOpcodesPreChronicle(t *testing.T) {
 	t.Parallel()
 
 	helloWorld := []byte("HelloWorld")
@@ -247,7 +247,7 @@ func TestChronicleOpcodes_PreChronicle(t *testing.T) {
 // TestChronicleOpcodes_PostChronicle verifies that every Chronicle-reactivated opcode
 // executes correctly in the post-Chronicle era.
 // Mirrors the POST_CHRONICLE phase in opcodes.py.
-func TestChronicleOpcodes_PostChronicle(t *testing.T) {
+func TestChronicleOpcodesPostChronicle(t *testing.T) {
 	t.Parallel()
 
 	helloWorld := []byte("HelloWorld")
@@ -410,7 +410,7 @@ func TestChronicleOpcodes_PostChronicle(t *testing.T) {
 }
 
 // TestChronicleOpcodes_EdgeCases covers boundary conditions for Chronicle opcodes.
-func TestChronicleOpcodes_EdgeCases(t *testing.T) {
+func TestChronicleOpcodesEdgeCases(t *testing.T) {
 	t.Parallel()
 
 	t.Run("OP_VER without tx returns error post-Chronicle", func(t *testing.T) {
@@ -583,7 +583,7 @@ func TestChronicleOpcodes_EdgeCases(t *testing.T) {
 // TestChronicleNopBehavior_WithoutDiscourageFlag verifies that the Chronicle NOP-type
 // opcodes (SUBSTR/LEFT/RIGHT/LSHIFTNUM/RSHIFTNUM) are silent NOPs pre-Chronicle when
 // the DiscourageUpgradableNops flag is absent, leaving extra items on the stack.
-func TestChronicleNopBehavior_WithoutDiscourageFlag(t *testing.T) {
+func TestChronicleNopBehaviorWithoutDiscourageFlag(t *testing.T) {
 	t.Parallel()
 
 	// Pre-Chronicle: OP_SUBSTR is a NOP, so stack ends up with extra items.

--- a/script/interpreter/config.go
+++ b/script/interpreter/config.go
@@ -4,6 +4,7 @@ import "math"
 
 type config interface {
 	AfterGenesis() bool
+	AfterChronicle() bool
 	MaxOps() int
 	MaxStackSize() int
 	MaxScriptSize() int
@@ -20,10 +21,14 @@ const (
 	MaxScriptElementSizeBeforeGenesis  = 520
 	MaxScriptNumberLengthBeforeGenesis = 4
 	MaxPubKeysPerMultiSigBeforeGenesis = 20
+
+	// MaxScriptNumberLengthAfterChronicle is the max script number length after the Chronicle upgrade (32MB).
+	MaxScriptNumberLengthAfterChronicle = 32 * 1024 * 1024
 )
 
 type beforeGenesisConfig struct{}
 type afterGenesisConfig struct{}
+type afterChronicleConfig struct{}
 
 func (a *afterGenesisConfig) AfterGenesis() bool {
 	return true
@@ -31,6 +36,22 @@ func (a *afterGenesisConfig) AfterGenesis() bool {
 
 func (b *beforeGenesisConfig) AfterGenesis() bool {
 	return false
+}
+
+func (c *afterChronicleConfig) AfterGenesis() bool {
+	return true
+}
+
+func (a *afterGenesisConfig) AfterChronicle() bool {
+	return false
+}
+
+func (b *beforeGenesisConfig) AfterChronicle() bool {
+	return false
+}
+
+func (c *afterChronicleConfig) AfterChronicle() bool {
+	return true
 }
 
 func (a *afterGenesisConfig) MaxStackSize() int {
@@ -79,4 +100,28 @@ func (a *afterGenesisConfig) MaxPubKeysPerMultiSig() int {
 
 func (b *beforeGenesisConfig) MaxPubKeysPerMultiSig() int {
 	return MaxPubKeysPerMultiSigBeforeGenesis
+}
+
+func (c *afterChronicleConfig) MaxStackSize() int {
+	return math.MaxInt32
+}
+
+func (c *afterChronicleConfig) MaxScriptSize() int {
+	return math.MaxInt32
+}
+
+func (c *afterChronicleConfig) MaxScriptElementSize() int {
+	return math.MaxInt32
+}
+
+func (c *afterChronicleConfig) MaxScriptNumberLength() int {
+	return MaxScriptNumberLengthAfterChronicle
+}
+
+func (c *afterChronicleConfig) MaxOps() int {
+	return math.MaxInt32
+}
+
+func (c *afterChronicleConfig) MaxPubKeysPerMultiSig() int {
+	return math.MaxInt32
 }

--- a/script/interpreter/operations.go
+++ b/script/interpreter/operations.go
@@ -2360,35 +2360,45 @@ func opcodeVerConditional(op *ParsedOpcode, t *thread) error {
 		return opcodeReserved(op, t)
 	}
 
-	// Post-Chronicle: version-based conditional (like IF/NOTIF with version comparison).
-	condVal := opCondFalse
-	if t.shouldExec(*op) {
-		if t.isBranchExecuting() {
-			top, err := t.dstack.PopByteArray()
-			if err != nil {
-				return errs.NewError(errs.ErrUnbalancedConditional,
-					"empty stack for %s", op.Name())
-			}
-			fValue := false
-			if len(top) == 4 && t.tx != nil {
-				v := t.tx.Version
-				versionBytes := []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
-				fValue = bytes.Equal(versionBytes, top)
-			}
-			if op.op.val == script.OpVERNOTIF {
-				fValue = !fValue
-			}
-			if fValue {
-				condVal = opCondTrue
-			}
-		} else {
-			condVal = opCondSkip
-		}
+	condVal, err := resolveVerCondition(op, t)
+	if err != nil {
+		return err
 	}
-
 	t.condStack = append(t.condStack, condVal)
 	t.elseStack.PushBool(false)
 	return nil
+}
+
+// resolveVerCondition evaluates the post-Chronicle OP_VERIF/OP_VERNOTIF condition.
+func resolveVerCondition(op *ParsedOpcode, t *thread) (int, error) {
+	if !t.shouldExec(*op) {
+		return opCondFalse, nil
+	}
+	if !t.isBranchExecuting() {
+		return opCondSkip, nil
+	}
+	top, err := t.dstack.PopByteArray()
+	if err != nil {
+		return 0, errs.NewError(errs.ErrUnbalancedConditional, "empty stack for %s", op.Name())
+	}
+	match := txVersionMatchesBytes(t.tx, top)
+	if op.op.val == script.OpVERNOTIF {
+		match = !match
+	}
+	if match {
+		return opCondTrue, nil
+	}
+	return opCondFalse, nil
+}
+
+// txVersionMatchesBytes reports whether data is exactly the 4-byte little-endian
+// encoding of tx.Version.
+func txVersionMatchesBytes(tx *transaction.Transaction, data []byte) bool {
+	if len(data) != 4 || tx == nil {
+		return false
+	}
+	v := tx.Version
+	return bytes.Equal([]byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}, data)
 }
 
 // opcode2Mul treats the top item on the data stack as an integer and replaces
@@ -2444,14 +2454,16 @@ func opcodeSubstr(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	offset := begin.Int()
-	ln := length.Int()
-	size := len(data)
-	if offset < 0 || offset >= size || ln < 0 || ln > size-offset {
+	offset64 := begin.Int64()
+	ln64 := length.Int64()
+	size := int64(len(data))
+	if offset64 < 0 || offset64 >= size || ln64 < 0 || ln64 > size-offset64 {
 		return errs.NewError(errs.ErrNumberTooBig, "OP_SUBSTR: invalid range offset=%d len=%d size=%d",
-			offset, ln, size)
+			offset64, ln64, size)
 	}
 
+	offset := int(offset64)
+	ln := int(ln64)
 	t.dstack.PushByteArray(data[offset : offset+ln])
 	return nil
 }
@@ -2477,12 +2489,13 @@ func opcodeLeft(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	ln := length.Int()
-	size := len(data)
-	if ln < 0 || ln > size {
-		return errs.NewError(errs.ErrNumberTooBig, "OP_LEFT: invalid length %d for size %d", ln, size)
+	ln64 := length.Int64()
+	size := int64(len(data))
+	if ln64 < 0 || ln64 > size {
+		return errs.NewError(errs.ErrNumberTooBig, "OP_LEFT: invalid length %d for size %d", ln64, size)
 	}
 
+	ln := int(ln64)
 	t.dstack.PushByteArray(data[:ln])
 	return nil
 }
@@ -2508,13 +2521,14 @@ func opcodeRight(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	ln := length.Int()
-	size := len(data)
-	if ln < 0 || ln > size {
-		return errs.NewError(errs.ErrNumberTooBig, "OP_RIGHT: invalid length %d for size %d", ln, size)
+	ln64 := length.Int64()
+	size := int64(len(data))
+	if ln64 < 0 || ln64 > size {
+		return errs.NewError(errs.ErrNumberTooBig, "OP_RIGHT: invalid length %d for size %d", ln64, size)
 	}
 
-	t.dstack.PushByteArray(data[size-ln:])
+	ln := int(ln64)
+	t.dstack.PushByteArray(data[int(size)-ln:])
 	return nil
 }
 
@@ -2543,7 +2557,14 @@ func opcodeLShiftNum(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	shiftAmt := uint(n.Int())
+	// Cap shift to max possible meaningful bits to prevent huge memory allocation.
+	// Any left shift larger than this will produce a result exceeding the size limit anyway.
+	const maxShiftBits = MaxScriptNumberLengthAfterChronicle * 8
+	shift64 := n.Int64()
+	if shift64 > maxShiftBits {
+		shift64 = maxShiftBits
+	}
+	shiftAmt := uint(shift64)
 	result := &ScriptNumber{
 		Val:          new(big.Int).Lsh(val.Val, shiftAmt),
 		AfterGenesis: t.afterGenesis,
@@ -2577,7 +2598,14 @@ func opcodeRShiftNum(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	shiftAmt := uint(n.Int())
+	// Cap shift to max possible meaningful bits to prevent huge memory allocation.
+	// Any right shift larger than the value's bit length produces 0.
+	const maxShiftBits = MaxScriptNumberLengthAfterChronicle * 8
+	shift64 := n.Int64()
+	if shift64 > maxShiftBits {
+		shift64 = maxShiftBits
+	}
+	shiftAmt := uint(shift64)
 	result := &ScriptNumber{
 		Val:          new(big.Int).Rsh(val.Val, shiftAmt),
 		AfterGenesis: t.afterGenesis,

--- a/script/interpreter/operations.go
+++ b/script/interpreter/operations.go
@@ -148,7 +148,7 @@ var opcodeArray = [256]opcode{
 
 	// Control opcodes.
 	script.OpNOP:                 {script.OpNOP, "OP_NOP", 1, opcodeNop},
-	script.OpVER:                 {script.OpVER, "OP_VER", 1, opcodeReserved},
+	script.OpVER:                 {script.OpVER, "OP_VER", 1, opcodeVer},
 	script.OpIF:                  {script.OpIF, "OP_IF", 1, opcodeIf},
 	script.OpNOTIF:               {script.OpNOTIF, "OP_NOTIF", 1, opcodeNotIf},
 	script.OpVERIF:               {script.OpVERIF, "OP_VERIF", 1, opcodeVerConditional},
@@ -201,8 +201,8 @@ var opcodeArray = [256]opcode{
 	// Numeric related opcodes.
 	script.Op1ADD:               {script.Op1ADD, "OP_1ADD", 1, opcode1Add},
 	script.Op1SUB:               {script.Op1SUB, "OP_1SUB", 1, opcode1Sub},
-	script.Op2MUL:               {script.Op2MUL, "OP_2MUL", 1, opcodeDisabled},
-	script.Op2DIV:               {script.Op2DIV, "OP_2DIV", 1, opcodeDisabled},
+	script.Op2MUL:               {script.Op2MUL, "OP_2MUL", 1, opcode2Mul},
+	script.Op2DIV:               {script.Op2DIV, "OP_2DIV", 1, opcode2Div},
 	script.OpNEGATE:             {script.OpNEGATE, "OP_NEGATE", 1, opcodeNegate},
 	script.OpABS:                {script.OpABS, "OP_ABS", 1, opcodeAbs},
 	script.OpNOT:                {script.OpNOT, "OP_NOT", 1, opcodeNot},
@@ -239,15 +239,15 @@ var opcodeArray = [256]opcode{
 	script.OpCHECKMULTISIG:       {script.OpCHECKMULTISIG, "OP_CHECKMULTISIG", 1, opcodeCheckMultiSig},
 	script.OpCHECKMULTISIGVERIFY: {script.OpCHECKMULTISIGVERIFY, "OP_CHECKMULTISIGVERIFY", 1, opcodeCheckMultiSigVerify},
 
-	// Reserved opcodes.
-	script.OpNOP1:  {script.OpNOP1, "OP_NOP1", 1, opcodeNop},
-	script.OpNOP4:  {script.OpNOP4, "OP_NOP4", 1, opcodeNop},
-	script.OpNOP5:  {script.OpNOP5, "OP_NOP5", 1, opcodeNop},
-	script.OpNOP6:  {script.OpNOP6, "OP_NOP6", 1, opcodeNop},
-	script.OpNOP7:  {script.OpNOP7, "OP_NOP7", 1, opcodeNop},
-	script.OpNOP8:  {script.OpNOP8, "OP_NOP8", 1, opcodeNop},
-	script.OpNOP9:  {script.OpNOP9, "OP_NOP9", 1, opcodeNop},
-	script.OpNOP10: {script.OpNOP10, "OP_NOP10", 1, opcodeNop},
+	// Reserved opcodes. NOP4-NOP8 are repurposed as Chronicle opcodes.
+	script.OpNOP1:    {script.OpNOP1, "OP_NOP1", 1, opcodeNop},
+	script.OpSUBSTR:  {script.OpSUBSTR, "OP_SUBSTR", 1, opcodeSubstr},
+	script.OpLEFT:    {script.OpLEFT, "OP_LEFT", 1, opcodeLeft},
+	script.OpRIGHT:   {script.OpRIGHT, "OP_RIGHT", 1, opcodeRight},
+	script.OpLSHIFTNUM: {script.OpLSHIFTNUM, "OP_LSHIFTNUM", 1, opcodeLShiftNum},
+	script.OpRSHIFTNUM: {script.OpRSHIFTNUM, "OP_RSHIFTNUM", 1, opcodeRShiftNum},
+	script.OpNOP9:    {script.OpNOP9, "OP_NOP9", 1, opcodeNop},
+	script.OpNOP10:   {script.OpNOP10, "OP_NOP10", 1, opcodeNop},
 
 	// Undefined opcodes.
 	script.OpUNKNOWN186: {script.OpUNKNOWN186, "OP_UNKNOWN186", 1, opcodeInvalid},
@@ -339,12 +339,6 @@ func opcodeDisabled(op *ParsedOpcode, t *thread) error {
 	return errs.NewError(errs.ErrDisabledOpcode, "attempt to execute disabled opcode %s", op.Name())
 }
 
-func opcodeVerConditional(op *ParsedOpcode, t *thread) error {
-	if t.afterGenesis && !t.shouldExec(*op) {
-		return nil
-	}
-	return opcodeReserved(op, t)
-}
 
 // opcodeReserved is a common handler for all reserved opcodes.  It returns an
 // appropriate error indicating the opcode is reserved.
@@ -2196,9 +2190,17 @@ func opcodeCheckMultiSig(op *ParsedOpcode, t *thread) error {
 	// Get script starting from the most recent script.OpCODESEPARATOR.
 	scr := t.subScript()
 
+	// Remove signatures and code separators from subscript, mirroring opcodeCheckSig.
+	// When ForkID is enabled, ForkID signatures use BIP143 digest and don't need cleanup.
 	for _, sigInfo := range signatures {
-		scr = scr.removeOpcodeByData(sigInfo.signature)
-		scr = scr.removeOpcode(script.OpCODESEPARATOR)
+		shf := sighash.Flag(0)
+		if len(sigInfo.signature) > 0 {
+			shf = sighash.Flag(sigInfo.signature[len(sigInfo.signature)-1])
+		}
+		if !t.hasFlag(scriptflag.EnableSighashForkID) || !shf.Has(sighash.ForkID) {
+			scr = scr.removeOpcodeByData(sigInfo.signature)
+			scr = scr.removeOpcode(script.OpCODESEPARATOR)
+		}
 	}
 
 	success := true
@@ -2330,4 +2332,256 @@ func opcodeCheckMultiSigVerify(op *ParsedOpcode, t *thread) error {
 
 func success() errs.Error {
 	return errs.NewError(errs.ErrOK, "success")
+}
+
+// opcodeVer pushes the transaction version as a 4-byte little-endian value.
+// Pre-Chronicle this opcode is reserved and returns an error.
+// Post-Chronicle (BSV v1.2.0) it pushes the tx version onto the stack.
+func opcodeVer(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		return opcodeReserved(op, t)
+	}
+	if t.tx == nil {
+		return errs.NewError(errs.ErrInvalidParams, "OP_VER requires a transaction")
+	}
+	v := t.tx.Version
+	t.dstack.PushByteArray([]byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)})
+	return nil
+}
+
+// opcodeVerConditional handles OP_VERIF and OP_VERNOTIF.
+// Pre-Chronicle: fails unless post-genesis in a non-executing branch (where it's a NOP).
+// Post-Chronicle: works like OP_IF/OP_NOTIF but compares top stack value against tx version.
+func opcodeVerConditional(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.afterGenesis && !t.shouldExec(*op) {
+			return nil
+		}
+		return opcodeReserved(op, t)
+	}
+
+	// Post-Chronicle: version-based conditional (like IF/NOTIF with version comparison).
+	condVal := opCondFalse
+	if t.shouldExec(*op) {
+		if t.isBranchExecuting() {
+			top, err := t.dstack.PopByteArray()
+			if err != nil {
+				return errs.NewError(errs.ErrUnbalancedConditional,
+					"empty stack for %s", op.Name())
+			}
+			fValue := false
+			if len(top) == 4 && t.tx != nil {
+				v := t.tx.Version
+				versionBytes := []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
+				fValue = bytes.Equal(versionBytes, top)
+			}
+			if op.op.val == script.OpVERNOTIF {
+				fValue = !fValue
+			}
+			if fValue {
+				condVal = opCondTrue
+			}
+		} else {
+			condVal = opCondSkip
+		}
+	}
+
+	t.condStack = append(t.condStack, condVal)
+	t.elseStack.PushBool(false)
+	return nil
+}
+
+// opcode2Mul treats the top item on the data stack as an integer and replaces
+// it with its value multiplied by 2.
+// This opcode was disabled before the Chronicle upgrade.
+func opcode2Mul(op *ParsedOpcode, t *thread) error {
+	m, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	two := &ScriptNumber{Val: big.NewInt(2), AfterGenesis: t.afterGenesis}
+	t.dstack.PushInt(m.Mul(two))
+	return nil
+}
+
+// opcode2Div treats the top item on the data stack as an integer and replaces
+// it with its value divided by 2, truncating towards zero.
+// This opcode was disabled before the Chronicle upgrade.
+func opcode2Div(op *ParsedOpcode, t *thread) error {
+	m, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	two := &ScriptNumber{Val: big.NewInt(2), AfterGenesis: t.afterGenesis}
+	t.dstack.PushInt(m.Div(two))
+	return nil
+}
+
+// opcodeSubstr extracts a substring from a byte array.
+// Pre-Chronicle: behaves as a NOP (with possible DiscourageUpgradableNops error).
+// Post-Chronicle: stack: [data begin len] -> [data[begin:begin+len]]
+func opcodeSubstr(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.hasFlag(scriptflag.DiscourageUpgradableNops) {
+			return errs.NewError(errs.ErrDiscourageUpgradableNOPs,
+				"OP_SUBSTR reserved for Chronicle upgrade")
+		}
+		return nil
+	}
+
+	length, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	begin, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	data, err := t.dstack.PopByteArray()
+	if err != nil {
+		return err
+	}
+
+	offset := begin.Int()
+	ln := length.Int()
+	size := len(data)
+	if offset < 0 || offset >= size || ln < 0 || ln > size-offset {
+		return errs.NewError(errs.ErrNumberTooBig, "OP_SUBSTR: invalid range offset=%d len=%d size=%d",
+			offset, ln, size)
+	}
+
+	t.dstack.PushByteArray(data[offset : offset+ln])
+	return nil
+}
+
+// opcodeLeft returns the left n bytes of a byte array.
+// Pre-Chronicle: behaves as a NOP (with possible DiscourageUpgradableNops error).
+// Post-Chronicle: stack: [data len] -> [data[:len]]
+func opcodeLeft(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.hasFlag(scriptflag.DiscourageUpgradableNops) {
+			return errs.NewError(errs.ErrDiscourageUpgradableNOPs,
+				"OP_LEFT reserved for Chronicle upgrade")
+		}
+		return nil
+	}
+
+	length, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	data, err := t.dstack.PopByteArray()
+	if err != nil {
+		return err
+	}
+
+	ln := length.Int()
+	size := len(data)
+	if ln < 0 || ln > size {
+		return errs.NewError(errs.ErrNumberTooBig, "OP_LEFT: invalid length %d for size %d", ln, size)
+	}
+
+	t.dstack.PushByteArray(data[:ln])
+	return nil
+}
+
+// opcodeRight returns the right n bytes of a byte array.
+// Pre-Chronicle: behaves as a NOP (with possible DiscourageUpgradableNops error).
+// Post-Chronicle: stack: [data len] -> [data[size-len:]]
+func opcodeRight(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.hasFlag(scriptflag.DiscourageUpgradableNops) {
+			return errs.NewError(errs.ErrDiscourageUpgradableNOPs,
+				"OP_RIGHT reserved for Chronicle upgrade")
+		}
+		return nil
+	}
+
+	length, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	data, err := t.dstack.PopByteArray()
+	if err != nil {
+		return err
+	}
+
+	ln := length.Int()
+	size := len(data)
+	if ln < 0 || ln > size {
+		return errs.NewError(errs.ErrNumberTooBig, "OP_RIGHT: invalid length %d for size %d", ln, size)
+	}
+
+	t.dstack.PushByteArray(data[size-ln:])
+	return nil
+}
+
+// opcodeLShiftNum performs an arithmetic left shift on a script number.
+// Pre-Chronicle: behaves as a NOP (with possible DiscourageUpgradableNops error).
+// Post-Chronicle: stack: [value n] -> [value << n]
+func opcodeLShiftNum(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.hasFlag(scriptflag.DiscourageUpgradableNops) {
+			return errs.NewError(errs.ErrDiscourageUpgradableNOPs,
+				"OP_LSHIFTNUM reserved for Chronicle upgrade")
+		}
+		return nil
+	}
+
+	n, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	if n.LessThanInt(0) {
+		return errs.NewError(errs.ErrNumberTooSmall, "OP_LSHIFTNUM: negative shift amount")
+	}
+
+	val, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	shiftAmt := uint(n.Int())
+	result := &ScriptNumber{
+		Val:          new(big.Int).Lsh(val.Val, shiftAmt),
+		AfterGenesis: t.afterGenesis,
+	}
+	t.dstack.PushInt(result)
+	return nil
+}
+
+// opcodeRShiftNum performs an arithmetic right shift on a script number.
+// Pre-Chronicle: behaves as a NOP (with possible DiscourageUpgradableNops error).
+// Post-Chronicle: stack: [value n] -> [value >> n]
+func opcodeRShiftNum(op *ParsedOpcode, t *thread) error {
+	if !t.afterChronicle {
+		if t.hasFlag(scriptflag.DiscourageUpgradableNops) {
+			return errs.NewError(errs.ErrDiscourageUpgradableNOPs,
+				"OP_RSHIFTNUM reserved for Chronicle upgrade")
+		}
+		return nil
+	}
+
+	n, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+	if n.LessThanInt(0) {
+		return errs.NewError(errs.ErrNumberTooSmall, "OP_RSHIFTNUM: negative shift amount")
+	}
+
+	val, err := t.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	shiftAmt := uint(n.Int())
+	result := &ScriptNumber{
+		Val:          new(big.Int).Rsh(val.Val, shiftAmt),
+		AfterGenesis: t.afterGenesis,
+	}
+	t.dstack.PushInt(result)
+	return nil
 }

--- a/script/interpreter/operations.go
+++ b/script/interpreter/operations.go
@@ -2479,25 +2479,7 @@ func opcodeLeft(op *ParsedOpcode, t *thread) error {
 		}
 		return nil
 	}
-
-	length, err := t.dstack.PopInt()
-	if err != nil {
-		return err
-	}
-	data, err := t.dstack.PopByteArray()
-	if err != nil {
-		return err
-	}
-
-	ln64 := length.Int64()
-	size := int64(len(data))
-	if ln64 < 0 || ln64 > size {
-		return errs.NewError(errs.ErrNumberTooBig, "OP_LEFT: invalid length %d for size %d", ln64, size)
-	}
-
-	ln := int(ln64)
-	t.dstack.PushByteArray(data[:ln])
-	return nil
+	return opcodeSliceBytes(t, "OP_LEFT", false)
 }
 
 // opcodeRight returns the right n bytes of a byte array.
@@ -2511,7 +2493,12 @@ func opcodeRight(op *ParsedOpcode, t *thread) error {
 		}
 		return nil
 	}
+	return opcodeSliceBytes(t, "OP_RIGHT", true)
+}
 
+// opcodeSliceBytes implements the shared logic for OP_LEFT and OP_RIGHT.
+// fromRight=false slices from the start (OP_LEFT); fromRight=true slices from the end (OP_RIGHT).
+func opcodeSliceBytes(t *thread, name string, fromRight bool) error {
 	length, err := t.dstack.PopInt()
 	if err != nil {
 		return err
@@ -2524,11 +2511,15 @@ func opcodeRight(op *ParsedOpcode, t *thread) error {
 	ln64 := length.Int64()
 	size := int64(len(data))
 	if ln64 < 0 || ln64 > size {
-		return errs.NewError(errs.ErrNumberTooBig, "OP_RIGHT: invalid length %d for size %d", ln64, size)
+		return errs.NewError(errs.ErrNumberTooBig, "%s: invalid length %d for size %d", name, ln64, size)
 	}
 
 	ln := int(ln64)
-	t.dstack.PushByteArray(data[int(size)-ln:])
+	if fromRight {
+		t.dstack.PushByteArray(data[int(size)-ln:])
+	} else {
+		t.dstack.PushByteArray(data[:ln])
+	}
 	return nil
 }
 
@@ -2543,34 +2534,7 @@ func opcodeLShiftNum(op *ParsedOpcode, t *thread) error {
 		}
 		return nil
 	}
-
-	n, err := t.dstack.PopInt()
-	if err != nil {
-		return err
-	}
-	if n.LessThanInt(0) {
-		return errs.NewError(errs.ErrNumberTooSmall, "OP_LSHIFTNUM: negative shift amount")
-	}
-
-	val, err := t.dstack.PopInt()
-	if err != nil {
-		return err
-	}
-
-	// Cap shift to max possible meaningful bits to prevent huge memory allocation.
-	// Any left shift larger than this will produce a result exceeding the size limit anyway.
-	const maxShiftBits = MaxScriptNumberLengthAfterChronicle * 8
-	shift64 := n.Int64()
-	if shift64 > maxShiftBits {
-		shift64 = maxShiftBits
-	}
-	shiftAmt := uint(shift64)
-	result := &ScriptNumber{
-		Val:          new(big.Int).Lsh(val.Val, shiftAmt),
-		AfterGenesis: t.afterGenesis,
-	}
-	t.dstack.PushInt(result)
-	return nil
+	return opcodeShiftNum(t, "OP_LSHIFTNUM", false)
 }
 
 // opcodeRShiftNum performs an arithmetic right shift on a script number.
@@ -2584,13 +2548,18 @@ func opcodeRShiftNum(op *ParsedOpcode, t *thread) error {
 		}
 		return nil
 	}
+	return opcodeShiftNum(t, "OP_RSHIFTNUM", true)
+}
 
+// opcodeShiftNum implements the shared logic for OP_LSHIFTNUM and OP_RSHIFTNUM.
+// rightShift=false performs a left shift; rightShift=true performs a right shift.
+func opcodeShiftNum(t *thread, name string, rightShift bool) error {
 	n, err := t.dstack.PopInt()
 	if err != nil {
 		return err
 	}
 	if n.LessThanInt(0) {
-		return errs.NewError(errs.ErrNumberTooSmall, "OP_RSHIFTNUM: negative shift amount")
+		return errs.NewError(errs.ErrNumberTooSmall, "%s: negative shift amount", name)
 	}
 
 	val, err := t.dstack.PopInt()
@@ -2598,18 +2567,20 @@ func opcodeRShiftNum(op *ParsedOpcode, t *thread) error {
 		return err
 	}
 
-	// Cap shift to max possible meaningful bits to prevent huge memory allocation.
-	// Any right shift larger than the value's bit length produces 0.
+	// Cap shift to avoid huge memory allocation; any shift beyond this saturates.
 	const maxShiftBits = MaxScriptNumberLengthAfterChronicle * 8
 	shift64 := n.Int64()
 	if shift64 > maxShiftBits {
 		shift64 = maxShiftBits
 	}
 	shiftAmt := uint(shift64)
-	result := &ScriptNumber{
-		Val:          new(big.Int).Rsh(val.Val, shiftAmt),
-		AfterGenesis: t.afterGenesis,
+
+	var shifted *big.Int
+	if rightShift {
+		shifted = new(big.Int).Rsh(val.Val, shiftAmt)
+	} else {
+		shifted = new(big.Int).Lsh(val.Val, shiftAmt)
 	}
-	t.dstack.PushInt(result)
+	t.dstack.PushInt(&ScriptNumber{Val: shifted, AfterGenesis: t.afterGenesis})
 	return nil
 }

--- a/script/interpreter/options.go
+++ b/script/interpreter/options.go
@@ -33,6 +33,15 @@ func WithAfterGenesis() ExecutionOptionFunc {
 	}
 }
 
+// WithAfterChronicle configure the execution to operate in an after-Chronicle context.
+// This also implies after-genesis. Chronicle is the BSV v1.2.0 protocol upgrade.
+func WithAfterChronicle() ExecutionOptionFunc {
+	return func(p *execOpts) {
+		p.flags.AddFlag(scriptflag.UTXOAfterGenesis)
+		p.flags.AddFlag(scriptflag.UTXOAfterChronicle)
+	}
+}
+
 // WithForkID configure the execution to allow a tx with a fork id.
 func WithForkID() ExecutionOptionFunc {
 	return func(p *execOpts) {

--- a/script/interpreter/reference_test.go
+++ b/script/interpreter/reference_test.go
@@ -37,6 +37,15 @@ func init() {
 	opcodeByName["OP_CHECKLOCKTIMEVERIFY"] = script.OpCHECKLOCKTIMEVERIFY
 	opcodeByName["OP_CHECKSEQUENCEVERIFY"] = script.OpCHECKSEQUENCEVERIFY
 	opcodeByName["OP_RESERVED"] = script.OpRESERVED
+	// Bitcoin Core reference tests use NOP4-NOP8 short names. Since Chronicle
+	// repurposed those bytes under Chronicle names (OP_SUBSTR etc.), the NOP
+	// aliases are no longer in opcodeArray. Re-add them so parseShortForm can
+	// strip "OP_" and produce the short forms "NOP4"-"NOP8".
+	opcodeByName["OP_NOP4"] = script.OpNOP4
+	opcodeByName["OP_NOP5"] = script.OpNOP5
+	opcodeByName["OP_NOP6"] = script.OpNOP6
+	opcodeByName["OP_NOP7"] = script.OpNOP7
+	opcodeByName["OP_NOP8"] = script.OpNOP8
 
 }
 

--- a/script/interpreter/scriptflag/scriptflag.go
+++ b/script/interpreter/scriptflag/scriptflag.go
@@ -78,6 +78,11 @@ const (
 	// VerifyMinimalIf defines the enforcement of any conditional statement using the
 	// minimum required data.
 	VerifyMinimalIf
+
+	// UTXOAfterChronicle defines that the utxo was created after
+	// the Chronicle upgrade, enabling Chronicle-era opcodes and rules.
+	// Chronicle cannot be set without UTXOAfterGenesis also being set.
+	UTXOAfterChronicle
 )
 
 // HasFlag returns whether the Flags has the passed flag set.

--- a/script/interpreter/thread.go
+++ b/script/interpreter/thread.go
@@ -283,6 +283,9 @@ func (t *thread) apply(opts *execOpts) error {
 		t.cfg = &afterGenesisConfig{}
 	}
 	if t.hasFlag(scriptflag.UTXOAfterChronicle) {
+		if !t.hasFlag(scriptflag.UTXOAfterGenesis) {
+			return errs.NewError(errs.ErrInvalidFlags, "UTXOAfterChronicle requires UTXOAfterGenesis")
+		}
 		t.afterChronicle = true
 		t.cfg = &afterChronicleConfig{}
 	}

--- a/script/interpreter/thread.go
+++ b/script/interpreter/thread.go
@@ -44,6 +44,7 @@ type thread struct {
 	bip16 bool // treat execution as pay-to-script-hash
 
 	afterGenesis            bool
+	afterChronicle          bool
 	earlyReturnAfterGenesis bool
 }
 
@@ -158,7 +159,8 @@ func (t *thread) executeOpcode(pop ParsedOpcode) error {
 	exec := t.shouldExec(pop)
 
 	// Disabled opcodes are fail on program counter.
-	if pop.IsDisabled() && (!t.afterGenesis || exec) {
+	// OP_2MUL and OP_2DIV are re-enabled post-Chronicle.
+	if pop.IsDisabled() && (!t.afterGenesis || exec) && !t.afterChronicle {
 		return errs.NewError(errs.ErrDisabledOpcode, "attempt to execute disabled opcode %s", pop.Name())
 	}
 
@@ -279,6 +281,10 @@ func (t *thread) apply(opts *execOpts) error {
 		t.elseStack = &stack{debug: &nopDebugger{}, sh: &nopStateHandler{}}
 		t.afterGenesis = true
 		t.cfg = &afterGenesisConfig{}
+	}
+	if t.hasFlag(scriptflag.UTXOAfterChronicle) {
+		t.afterChronicle = true
+		t.cfg = &afterChronicleConfig{}
 	}
 
 	uscript := opts.unlockingScript

--- a/script/opcodes.go
+++ b/script/opcodes.go
@@ -722,11 +722,11 @@ var OpCodeValues = map[byte]string{
 	OpNOP1:                "OP_NOP1",
 	OpNOP2:                "OP_NOP2",
 	OpNOP3:                "OP_NOP3",
-	OpNOP4:                "OP_NOP4",
-	OpNOP5:                "OP_NOP5",
-	OpNOP6:                "OP_NOP6",
-	OpNOP7:                "OP_NOP7",
-	OpNOP8:                "OP_NOP8",
+	OpSUBSTR:              "OP_SUBSTR",   // 0xb3 – Chronicle name takes precedence over OP_NOP4
+	OpLEFT:                "OP_LEFT",     // 0xb4 – Chronicle name takes precedence over OP_NOP5
+	OpRIGHT:               "OP_RIGHT",    // 0xb5 – Chronicle name takes precedence over OP_NOP6
+	OpLSHIFTNUM:           "OP_LSHIFTNUM", // 0xb6 – Chronicle name takes precedence over OP_NOP7
+	OpRSHIFTNUM:           "OP_RSHIFTNUM", // 0xb7 – Chronicle name takes precedence over OP_NOP8
 	OpNOP9:                "OP_NOP9",
 	OpNOP10:               "OP_NOP10",
 	OpUNKNOWN186:          "OP_UNKNOWN186",

--- a/script/opcodes.go
+++ b/script/opcodes.go
@@ -190,10 +190,15 @@ const (
 	OpNOP3                byte = 0xb2 // 178
 	OpCHECKSEQUENCEVERIFY byte = 0xb2 // 178
 	OpNOP4                byte = 0xb3 // 179
+	OpSUBSTR              byte = 0xb3 // 179 - Chronicle: substring operation (was NOP4)
 	OpNOP5                byte = 0xb4 // 180
+	OpLEFT                byte = 0xb4 // 180 - Chronicle: left substring (was NOP5)
 	OpNOP6                byte = 0xb5 // 181
+	OpRIGHT               byte = 0xb5 // 181 - Chronicle: right substring (was NOP6)
 	OpNOP7                byte = 0xb6 // 182
+	OpLSHIFTNUM           byte = 0xb6 // 182 - Chronicle: numeric left shift (was NOP7)
 	OpNOP8                byte = 0xb7 // 183
+	OpRSHIFTNUM           byte = 0xb7 // 183 - Chronicle: numeric right shift (was NOP8)
 	OpNOP9                byte = 0xb8 // 184
 	OpNOP10               byte = 0xb9 // 185
 	OpUNKNOWN186          byte = 0xba // 186
@@ -403,9 +408,7 @@ var OpCodeStrings = map[string]byte{
 	"OP_CAT":                 OpCAT,
 	"OP_SPLIT":               OpSPLIT,
 	"OP_NUM2BIN":             OpNUM2BIN,
-	"OP_LEFT":                OpNUM2BIN,
 	"OP_BIN2NUM":             OpBIN2NUM,
-	"OP_RIGHT":               OpBIN2NUM,
 	"OP_SIZE":                OpSIZE,
 	"OP_INVERT":              OpINVERT,
 	"OP_AND":                 OpAND,
@@ -456,10 +459,15 @@ var OpCodeStrings = map[string]byte{
 	"OP_NOP2":                OpNOP2,
 	"OP_NOP3":                OpNOP3,
 	"OP_NOP4":                OpNOP4,
+	"OP_SUBSTR":              OpSUBSTR,
 	"OP_NOP5":                OpNOP5,
+	"OP_LEFT":                OpLEFT,
 	"OP_NOP6":                OpNOP6,
+	"OP_RIGHT":               OpRIGHT,
 	"OP_NOP7":                OpNOP7,
+	"OP_LSHIFTNUM":           OpLSHIFTNUM,
 	"OP_NOP8":                OpNOP8,
+	"OP_RSHIFTNUM":           OpRSHIFTNUM,
 	"OP_NOP9":                OpNOP9,
 	"OP_NOP10":               OpNOP10,
 	"OP_UNKNOWN186":          OpUNKNOWN186,

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -1010,6 +1010,8 @@ func TestScriptPubKey(t *testing.T) {
 func TestChronicleOpcodeASMRoundTrip(t *testing.T) {
 	t.Parallel()
 
+	const rshiftnumCompoundASM = "OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL"
+
 	// toASM: single-opcode scripts must use Chronicle names, not NOP aliases.
 	toASMTests := []struct {
 		name   string
@@ -1033,7 +1035,7 @@ func TestChronicleOpcodeASMRoundTrip(t *testing.T) {
 		// Compound: 0x51 0x52 0xb6 0x54 0x87  (ts-sdk: '1 << 2 = 4')
 		{"OP_LSHIFTNUM compound 2", "5152b65487", "OP_TRUE OP_2 OP_LSHIFTNUM OP_4 OP_EQUAL"},
 		// Compound: 0x60 0x52 0xb7 0x54 0x87  (ts-sdk: '16 >> 2 = 4')
-		{"OP_RSHIFTNUM compound", "6052b75487", "OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL"},
+		{"OP_RSHIFTNUM compound", "6052b75487", rshiftnumCompoundASM},
 		// Compound: 0x54 0x52 0xb7 0x51 0x87  (ts-sdk: '4 >> 2 = 1')
 		{"OP_RSHIFTNUM compound 2", "5452b75187", "OP_4 OP_2 OP_RSHIFTNUM OP_TRUE OP_EQUAL"},
 	}
@@ -1067,7 +1069,7 @@ func TestChronicleOpcodeASMRoundTrip(t *testing.T) {
 		// ts-sdk uses "OP_1" which go-sdk's OpCodeStrings also accepts.
 		{"LSHIFTNUM asm OP_1 alias", "OP_1 OP_1 OP_LSHIFTNUM OP_2 OP_EQUAL", "5151b65287"},
 		// Using go-sdk canonical names for the round-trip.
-		{"RSHIFTNUM compound asm", "OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL", "6052b75487"},
+		{"RSHIFTNUM compound asm", rshiftnumCompoundASM, "6052b75487"},
 	}
 
 	for _, tc := range fromASMTests {
@@ -1089,7 +1091,7 @@ func TestChronicleOpcodeASMRoundTrip(t *testing.T) {
 		"OP_RSHIFTNUM",
 		"OP_TRUE OP_TRUE OP_LSHIFTNUM OP_2 OP_EQUAL",
 		"OP_TRUE OP_2 OP_LSHIFTNUM OP_4 OP_EQUAL",
-		"OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL",
+		rshiftnumCompoundASM,
 		"OP_4 OP_2 OP_RSHIFTNUM OP_TRUE OP_EQUAL",
 		"OP_2 OP_TRUE OP_RSHIFTNUM OP_TRUE OP_EQUAL",
 	}

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -1000,3 +1000,106 @@ func TestScriptPubKey(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid square root")
 	require.Nil(t, pubKey)
 }
+
+// TestChronicleOpcodeASMRoundTrip verifies that Chronicle opcodes (OP_SUBSTR, OP_LEFT,
+// OP_RIGHT, OP_LSHIFTNUM, OP_RSHIFTNUM) serialize to their Chronicle names in ToASM
+// and can be parsed back via NewFromASM – matching the canonical ASM used by the ts-sdk.
+//
+// Test cases are derived from the ts-sdk ChronicleOpcodes.test.ts ASM round-trip tests:
+// https://github.com/bsv-blockchain/ts-sdk/blob/main/src/script/__tests/ChronicleOpcodes.test.ts
+func TestChronicleOpcodeASMRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// toASM: single-opcode scripts must use Chronicle names, not NOP aliases.
+	toASMTests := []struct {
+		name   string
+		hex    string
+		expASM string
+	}{
+		// 0xb3 → OP_SUBSTR (not OP_NOP4)
+		{"OP_SUBSTR disasm", "b3", "OP_SUBSTR"},
+		// 0xb4 → OP_LEFT (not OP_NOP5)
+		{"OP_LEFT disasm", "b4", "OP_LEFT"},
+		// 0xb5 → OP_RIGHT (not OP_NOP6)
+		{"OP_RIGHT disasm", "b5", "OP_RIGHT"},
+		// 0xb6 → OP_LSHIFTNUM (not OP_NOP7)
+		{"OP_LSHIFTNUM disasm", "b6", "OP_LSHIFTNUM"},
+		// 0xb7 → OP_RSHIFTNUM (not OP_NOP8)
+		{"OP_RSHIFTNUM disasm", "b7", "OP_RSHIFTNUM"},
+		// Compound scripts use go-sdk canonical names (OP_TRUE for 0x51, not OP_1).
+		// ts-sdk uses OP_1 for 0x51; go-sdk OpCodeValues maps 0x51 → OP_TRUE.
+		// Compound: 0x51 0x51 0xb6 0x52 0x87  (ts-sdk: '1 << 1 = 2')
+		{"OP_LSHIFTNUM compound", "5151b65287", "OP_TRUE OP_TRUE OP_LSHIFTNUM OP_2 OP_EQUAL"},
+		// Compound: 0x51 0x52 0xb6 0x54 0x87  (ts-sdk: '1 << 2 = 4')
+		{"OP_LSHIFTNUM compound 2", "5152b65487", "OP_TRUE OP_2 OP_LSHIFTNUM OP_4 OP_EQUAL"},
+		// Compound: 0x60 0x52 0xb7 0x54 0x87  (ts-sdk: '16 >> 2 = 4')
+		{"OP_RSHIFTNUM compound", "6052b75487", "OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL"},
+		// Compound: 0x54 0x52 0xb7 0x51 0x87  (ts-sdk: '4 >> 2 = 1')
+		{"OP_RSHIFTNUM compound 2", "5452b75187", "OP_4 OP_2 OP_RSHIFTNUM OP_TRUE OP_EQUAL"},
+	}
+
+	for _, tc := range toASMTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := script.NewFromHex(tc.hex)
+			require.NoError(t, err)
+			require.Equal(t, tc.expASM, s.ToASM())
+		})
+	}
+
+	// fromASM → hex: Chronicle names must assemble to the correct bytes.
+	fromASMTests := []struct {
+		name   string
+		asm    string
+		expHex string
+	}{
+		{"OP_SUBSTR asm", "OP_SUBSTR", "b3"},
+		{"OP_LEFT asm", "OP_LEFT", "b4"},
+		{"OP_RIGHT asm", "OP_RIGHT", "b5"},
+		{"OP_LSHIFTNUM asm", "OP_LSHIFTNUM", "b6"},
+		{"OP_RSHIFTNUM asm", "OP_RSHIFTNUM", "b7"},
+		// NOP aliases must still assemble to the same bytes.
+		{"OP_NOP4 asm (→ b3)", "OP_NOP4", "b3"},
+		{"OP_NOP5 asm (→ b4)", "OP_NOP5", "b4"},
+		{"OP_NOP6 asm (→ b5)", "OP_NOP6", "b5"},
+		{"OP_NOP7 asm (→ b6)", "OP_NOP7", "b6"},
+		{"OP_NOP8 asm (→ b7)", "OP_NOP8", "b7"},
+		// ts-sdk uses "OP_1" which go-sdk's OpCodeStrings also accepts.
+		{"LSHIFTNUM asm OP_1 alias", "OP_1 OP_1 OP_LSHIFTNUM OP_2 OP_EQUAL", "5151b65287"},
+		// Using go-sdk canonical names for the round-trip.
+		{"RSHIFTNUM compound asm", "OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL", "6052b75487"},
+	}
+
+	for _, tc := range fromASMTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := script.NewFromASM(tc.asm)
+			require.NoError(t, err)
+			require.Equal(t, tc.expHex, hex.EncodeToString(*s))
+		})
+	}
+
+	// Full round-trip: ToASM(NewFromASM(asm)) == asm for Chronicle opcodes.
+	// Uses go-sdk canonical names (OP_TRUE for 0x51, etc.) so the round-trip is exact.
+	roundTripTests := []string{
+		"OP_SUBSTR",
+		"OP_LEFT",
+		"OP_RIGHT",
+		"OP_LSHIFTNUM",
+		"OP_RSHIFTNUM",
+		"OP_TRUE OP_TRUE OP_LSHIFTNUM OP_2 OP_EQUAL",
+		"OP_TRUE OP_2 OP_LSHIFTNUM OP_4 OP_EQUAL",
+		"OP_16 OP_2 OP_RSHIFTNUM OP_4 OP_EQUAL",
+		"OP_4 OP_2 OP_RSHIFTNUM OP_TRUE OP_EQUAL",
+		"OP_2 OP_TRUE OP_RSHIFTNUM OP_TRUE OP_EQUAL",
+	}
+
+	for _, asm := range roundTripTests {
+		t.Run("roundtrip "+asm, func(t *testing.T) {
+			t.Parallel()
+			s, err := script.NewFromASM(asm)
+			require.NoError(t, err)
+			require.Equal(t, asm, s.ToASM())
+		})
+	}
+}

--- a/transaction/merklepath.go
+++ b/transaction/merklepath.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math/bits"
 	"slices"
 	"sort"
 
@@ -31,8 +32,11 @@ type MerklePath struct {
 type IndexedPath []map[uint64]*PathElement
 
 func (ip IndexedPath) GetOffsetLeaf(layer int, offset uint64) *PathElement {
-	if leaf, ok := ip[layer][offset]; ok {
-		return leaf
+	// Guard: layer may exceed stored levels for single-level compound paths
+	if layer < len(ip) {
+		if leaf, ok := ip[layer][offset]; ok {
+			return leaf
+		}
 	}
 	if layer == 0 {
 		return nil
@@ -251,7 +255,19 @@ func (mp *MerklePath) ComputeRoot(txid *chainhash.Hash) (*chainhash.Hash, error)
 	workingHash := txLeaf.Hash
 	index := txLeaf.Offset
 
-	for height := range mp.Path {
+	// Compute effective tree height from max offset (handles single-level compound paths)
+	var maxOffset uint64
+	for _, l := range mp.Path[0] {
+		if l.Offset > maxOffset {
+			maxOffset = l.Offset
+		}
+	}
+	effectiveHeight := len(mp.Path)
+	if bitsNeeded := bits.Len64(maxOffset); bitsNeeded > effectiveHeight {
+		effectiveHeight = bitsNeeded
+	}
+
+	for height := 0; height < effectiveHeight; height++ {
 		offset := (index >> height) ^ 1
 		leaf := indexedPath.GetOffsetLeaf(height, offset)
 		if leaf == nil {

--- a/transaction/merklepath_test.go
+++ b/transaction/merklepath_test.go
@@ -319,6 +319,76 @@ func TestMerklePathClone(t *testing.T) {
 	})
 }
 
+func TestMerklePathSingleLevelCompound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single-level compound path computes correct root", func(t *testing.T) {
+		leaf0, _ := chainhash.NewHashFromHex("0000000000000000000000000000000000000000000000000000000000000001")
+		leaf1, _ := chainhash.NewHashFromHex("0000000000000000000000000000000000000000000000000000000000000002")
+		leaf2, _ := chainhash.NewHashFromHex("0000000000000000000000000000000000000000000000000000000000000003")
+		leaf3, _ := chainhash.NewHashFromHex("0000000000000000000000000000000000000000000000000000000000000004")
+
+		h01 := MerkleTreeParent(leaf0, leaf1)
+		h23 := MerkleTreeParent(leaf2, leaf3)
+		expectedRoot := MerkleTreeParent(h01, h23)
+
+		txid := true
+		mp := &MerklePath{
+			BlockHeight: 1000,
+			Path: [][]*PathElement{
+				{
+					{Offset: 0, Hash: leaf0, Txid: &txid},
+					{Offset: 1, Hash: leaf1, Txid: &txid},
+					{Offset: 2, Hash: leaf2, Txid: &txid},
+					{Offset: 3, Hash: leaf3, Txid: &txid},
+				},
+			},
+		}
+
+		for _, leaf := range mp.Path[0] {
+			root, err := mp.ComputeRoot(leaf.Hash)
+			require.NoError(t, err)
+			require.Equal(t, expectedRoot.String(), root.String(), "root mismatch for offset %d", leaf.Offset)
+		}
+	})
+}
+
+func TestMerklePathCombineRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("combine serialize deserialize verify", func(t *testing.T) {
+		path0A := BRC74JSON.Path[0][:2]
+		path0B := BRC74JSON.Path[0][2:]
+		path1A := BRC74JSON.Path[1][1:]
+		path1B := BRC74JSON.Path[1][:1]
+		pathRest := BRC74JSON.Path[2:]
+
+		pathA := MerklePath{
+			BlockHeight: BRC74JSON.BlockHeight,
+			Path:        append([][]*PathElement{path0A, path1A}, pathRest...),
+		}
+		pathB := MerklePath{
+			BlockHeight: BRC74JSON.BlockHeight,
+			Path:        append([][]*PathElement{path0B, path1B}, pathRest...),
+		}
+
+		err := pathA.Combine(&pathB)
+		require.NoError(t, err)
+
+		hexStr := pathA.Hex()
+		decoded, err := NewMerklePathFromHex(hexStr)
+		require.NoError(t, err)
+
+		root, err := decoded.ComputeRootHex(&BRC74TXID2)
+		require.NoError(t, err)
+		require.Equal(t, BRC74Root, root)
+
+		root, err = decoded.ComputeRootHex(&BRC74TXID3)
+		require.NoError(t, err)
+		require.Equal(t, BRC74Root, root)
+	})
+}
+
 func TestMerklePathAddLeafAndComputeMissingHashes(t *testing.T) {
 	t.Run("builds path from leaves and computes intermediate hashes", func(t *testing.T) {
 		// Create 4 leaf hashes


### PR DESCRIPTION
Audit and correct every opcode in the script/interpreter packages to match
byte-for-byte execution fidelity with BSV node v1.2.0 (Chronicle upgrade).

Key changes:
- scriptflag: add UTXOAfterChronicle flag (bit 21, SCRIPT_UTXO_AFTER_CHRONICLE)
- config: add afterChronicleConfig with 32MB MaxScriptNumberLength; add
  AfterChronicle() bool to config interface
- opcodes.go: add Chronicle opcode aliases (OpSUBSTR, OpLEFT, OpRIGHT,
  OpLSHIFTNUM, OpRSHIFTNUM at 0xb3-0xb7); remove stale OP_LEFT/OP_RIGHT
  aliases that mapped to OpNUM2BIN/OpBIN2NUM
- thread.go: add afterChronicle field; initialise afterChronicleConfig when
  UTXOAfterChronicle flag set; allow OP_2MUL/OP_2DIV past the disabled-opcode
  check post-Chronicle
- operations.go:
  - OP_VER (0x62): pre-Chronicle reserved/illegal; post-Chronicle pushes
    tx version as 4-byte LE uint32 (matches C++ checker.Version())
  - OP_VERIF/OP_VERNOTIF (0x65/0x66): pre-Chronicle always-illegal; post-
    Chronicle act as version-based conditionals comparing stack top against
    tx version (C++ [[fallthrough]] into IF/NOTIF logic)
  - OP_2MUL/OP_2DIV (0x8d/0x8e): re-enabled post-Chronicle; multiply/divide
    top stack integer by 2
  - OP_SUBSTR/NOP4 (0xb3): NOP pre-Chronicle; substring(begin,len) post-
    Chronicle
  - OP_LEFT/NOP5 (0xb4): NOP pre-Chronicle; left N bytes post-Chronicle
  - OP_RIGHT/NOP6 (0xb5): NOP pre-Chronicle; right N bytes post-Chronicle
  - OP_LSHIFTNUM/NOP7 (0xb6): NOP pre-Chronicle; arithmetic left shift
    post-Chronicle
  - OP_RSHIFTNUM/NOP8 (0xb7): NOP pre-Chronicle; arithmetic right shift
    post-Chronicle
  - opcodeCheckMultiSig: fix ForkID subscript cleanup to skip removeOpcodeByData
    per-signature when ForkID flag is set (matches opcodeCheckSig behaviour and
    BSV C++ node logic)
- options.go: add WithAfterChronicle() execution option
- merklepath.go: fix compound MerklePath root computation for single-level paths
  - GetOffsetLeaf: guard against layer index exceeding stored levels (prevents
    out-of-bounds panic on single-level compound paths)
  - ComputeRoot: compute effective tree height from max offset using bits.Len64
    so single-level compound paths (all leaves at height 0) traverse the correct
    number of levels rather than stopping after one iteration
- merklepath_test.go: add TestMerklePathSingleLevelCompound (verifies all four
  leaves in a single-level compound path compute the correct root) and
  TestMerklePathCombineRoundTrip (combine + hex serialize/deserialize +
  ComputeRootHex round-trip for both txids)