### PR TITLE
fix: resolve panic when calling TxID() on BEEF_V2 parsed transaction

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -20,6 +20,7 @@ type Beef struct {
 	Version      uint32
 	BUMPs        []*MerklePath
 	Transactions map[chainhash.Hash]*BeefTx
+	NewestTxID   *chainhash.Hash
 }
 
 func NewBeef() *Beef {
@@ -59,25 +60,26 @@ func newEmptyBeef(version uint32) *Beef {
 	}
 }
 
-func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]*BeefTx, error) {
+func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]*BeefTx, *chainhash.Hash, error) {
 	var numberOfTransactions util.VarInt
 	_, err := numberOfTransactions.ReadFrom(reader)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	txs := make(map[chainhash.Hash]*BeefTx, 0)
+	var lastTxID *chainhash.Hash
 	for i := 0; i < int(numberOfTransactions); i++ {
 		formatByte, err := reader.ReadByte()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		var beefTx BeefTx
 		beefTx.DataFormat = DataFormat(formatByte)
 		beefTx.Transaction = &Transaction{}
 
 		if beefTx.DataFormat > TxIDOnly {
-			return nil, fmt.Errorf("invalid data format: %d", formatByte)
+			return nil, nil, fmt.Errorf("invalid data format: %d", formatByte)
 		}
 
 		if beefTx.DataFormat == TxIDOnly {
@@ -85,9 +87,10 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 			_, err = reader.Read(txid[:])
 			beefTx.KnownTxID = &txid
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			txs[txid] = &beefTx
+			lastTxID = &txid
 		} else {
 			bump := beefTx.DataFormat == RawTxAndBumpIndex
 			// read the index of the bump
@@ -95,14 +98,14 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 			if bump {
 				_, err := bumpIndex.ReadFrom(reader)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				beefTx.BumpIndex = int(bumpIndex)
 			}
 			// read the transaction data
 			_, err = beefTx.Transaction.ReadFrom(reader)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			// attach the bump
 			if bump {
@@ -115,12 +118,14 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 				}
 			}
 
-			txs[*beefTx.Transaction.TxID()] = &beefTx
+			txid := beefTx.Transaction.TxID()
+			txs[*txid] = &beefTx
+			lastTxID = txid
 		}
 
 	}
 
-	return &txs, nil
+	return &txs, lastTxID, nil
 }
 
 func NewBeefFromHex(beefHex string) (*Beef, error) {
@@ -149,7 +154,7 @@ func NewBeefFromBytes(beef []byte) (*Beef, error) {
 			return nil, err
 		}
 
-		txs, _, err := readAllTransactions(reader, BUMPs)
+		txs, lastTx, err := readAllTransactions(reader, BUMPs)
 		if err != nil {
 			return nil, err
 		}
@@ -180,10 +185,16 @@ func NewBeefFromBytes(beef []byte) (*Beef, error) {
 			}
 		}
 
+		var newestTxID *chainhash.Hash
+		if lastTx != nil {
+			newestTxID = lastTx.TxID()
+		}
+
 		return &Beef{
 			Version:      version,
 			BUMPs:        BUMPs,
 			Transactions: beefTxs,
+			NewestTxID:   newestTxID,
 		}, nil
 	}
 
@@ -192,7 +203,7 @@ func NewBeefFromBytes(beef []byte) (*Beef, error) {
 		return nil, err
 	}
 
-	txs, err := readBeefTx(reader, BUMPs)
+	txs, lastTxID, err := readBeefTx(reader, BUMPs)
 	if err != nil {
 		return nil, err
 	}
@@ -201,6 +212,7 @@ func NewBeefFromBytes(beef []byte) (*Beef, error) {
 		Version:      version,
 		BUMPs:        BUMPs,
 		Transactions: *txs,
+		NewestTxID:   lastTxID,
 	}, nil
 }
 
@@ -247,7 +259,8 @@ func ParseBeef(beefBytes []byte) (*Beef, *Transaction, *chainhash.Hash, error) {
 		if beef, err := NewBeefFromBytes(beefBytes); err != nil {
 			return nil, nil, nil, err
 		} else {
-			return beef, nil, nil, nil
+			tx := beef.FindTransactionByHash(beef.NewestTxID)
+			return beef, tx, beef.NewestTxID, nil
 		}
 	default:
 		return nil, nil, nil, fmt.Errorf("invalid-atomic-beef")

--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -60,10 +60,45 @@ func newEmptyBeef(version uint32) *Beef {
 	}
 }
 
+func readBeefTxIDOnly(reader *bytes.Reader, beefTx *BeefTx) (*chainhash.Hash, error) {
+	var txid chainhash.Hash
+	if _, err := reader.Read(txid[:]); err != nil {
+		return nil, err
+	}
+	beefTx.KnownTxID = &txid
+	return &txid, nil
+}
+
+func readBeefTxFull(reader *bytes.Reader, beefTx *BeefTx, BUMPs []*MerklePath, txs map[chainhash.Hash]*BeefTx) (*chainhash.Hash, error) {
+	bump := beefTx.DataFormat == RawTxAndBumpIndex
+	var bumpIndex util.VarInt
+	if bump {
+		if _, err := bumpIndex.ReadFrom(reader); err != nil {
+			return nil, err
+		}
+		beefTx.BumpIndex = int(bumpIndex)
+	}
+
+	if _, err := beefTx.Transaction.ReadFrom(reader); err != nil {
+		return nil, err
+	}
+
+	if bump {
+		beefTx.Transaction.MerklePath = BUMPs[int(bumpIndex)]
+	}
+
+	for _, input := range beefTx.Transaction.Inputs {
+		if sourceObj, ok := txs[*input.SourceTXID]; ok {
+			input.SourceTransaction = sourceObj.Transaction
+		}
+	}
+
+	return beefTx.Transaction.TxID(), nil
+}
+
 func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]*BeefTx, *chainhash.Hash, error) {
 	var numberOfTransactions util.VarInt
-	_, err := numberOfTransactions.ReadFrom(reader)
-	if err != nil {
+	if _, err := numberOfTransactions.ReadFrom(reader); err != nil {
 		return nil, nil, err
 	}
 
@@ -74,55 +109,25 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 		if err != nil {
 			return nil, nil, err
 		}
-		var beefTx BeefTx
-		beefTx.DataFormat = DataFormat(formatByte)
-		beefTx.Transaction = &Transaction{}
-
+		beefTx := BeefTx{
+			DataFormat:  DataFormat(formatByte),
+			Transaction: &Transaction{},
+		}
 		if beefTx.DataFormat > TxIDOnly {
 			return nil, nil, fmt.Errorf("invalid data format: %d", formatByte)
 		}
 
+		var txid *chainhash.Hash
 		if beefTx.DataFormat == TxIDOnly {
-			var txid chainhash.Hash
-			_, err = reader.Read(txid[:])
-			beefTx.KnownTxID = &txid
-			if err != nil {
-				return nil, nil, err
-			}
-			txs[txid] = &beefTx
-			lastTxID = &txid
+			txid, err = readBeefTxIDOnly(reader, &beefTx)
 		} else {
-			bump := beefTx.DataFormat == RawTxAndBumpIndex
-			// read the index of the bump
-			var bumpIndex util.VarInt
-			if bump {
-				_, err := bumpIndex.ReadFrom(reader)
-				if err != nil {
-					return nil, nil, err
-				}
-				beefTx.BumpIndex = int(bumpIndex)
-			}
-			// read the transaction data
-			_, err = beefTx.Transaction.ReadFrom(reader)
-			if err != nil {
-				return nil, nil, err
-			}
-			// attach the bump
-			if bump {
-				beefTx.Transaction.MerklePath = BUMPs[int(bumpIndex)]
-			}
-
-			for _, input := range beefTx.Transaction.Inputs {
-				if sourceObj, ok := txs[*input.SourceTXID]; ok {
-					input.SourceTransaction = sourceObj.Transaction
-				}
-			}
-
-			txid := beefTx.Transaction.TxID()
-			txs[*txid] = &beefTx
-			lastTxID = txid
+			txid, err = readBeefTxFull(reader, &beefTx, BUMPs, txs)
 		}
-
+		if err != nil {
+			return nil, nil, err
+		}
+		txs[*txid] = &beefTx
+		lastTxID = txid
 	}
 
 	return &txs, lastTxID, nil

--- a/transaction/beef_test.go
+++ b/transaction/beef_test.go
@@ -1364,6 +1364,60 @@ func TestBeefVerify(t *testing.T) {
 	}
 }
 
+func TestReadBeefTxErrors(t *testing.T) {
+	bumps := []*MerklePath{}
+
+	t.Run("truncated TxIDOnly", func(t *testing.T) {
+		// Format byte = TxIDOnly (2), but no txid bytes follow
+		data := []byte{1} // 1 transaction
+		data = append(data, byte(TxIDOnly))
+		reader := bytes.NewReader(data)
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+
+	t.Run("truncated RawTxAndBumpIndex", func(t *testing.T) {
+		// Format byte = RawTxAndBumpIndex (1), but no bump index follows
+		data := []byte{1} // 1 transaction
+		data = append(data, byte(RawTxAndBumpIndex))
+		reader := bytes.NewReader(data)
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+
+	t.Run("truncated RawTx", func(t *testing.T) {
+		// Format byte = RawTx (0), but no tx data follows
+		data := []byte{1} // 1 transaction
+		data = append(data, byte(RawTx))
+		reader := bytes.NewReader(data)
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+
+	t.Run("truncated format byte", func(t *testing.T) {
+		// Says 1 transaction but no format byte
+		data := []byte{1}
+		reader := bytes.NewReader(data)
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+
+	t.Run("empty reader", func(t *testing.T) {
+		// Cannot read numberOfTransactions varint
+		reader := bytes.NewReader([]byte{})
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid data format", func(t *testing.T) {
+		data := []byte{1}        // 1 transaction
+		data = append(data, 0x03) // invalid format > TxIDOnly
+		reader := bytes.NewReader(data)
+		_, _, err := readBeefTx(reader, bumps)
+		require.Error(t, err)
+	})
+}
+
 func TestParseBeefV2ReturnsTxAndTxID(t *testing.T) {
 	beefBytes, err := hex.DecodeString(BEEFSet)
 	require.NoError(t, err)

--- a/transaction/beef_test.go
+++ b/transaction/beef_test.go
@@ -1363,3 +1363,31 @@ func TestBeefVerify(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBeefV2ReturnsTxAndTxID(t *testing.T) {
+	beefBytes, err := hex.DecodeString(BEEFSet)
+	require.NoError(t, err)
+
+	beef, tx, txid, err := ParseBeef(beefBytes)
+	require.NoError(t, err)
+	require.NotNil(t, beef)
+	require.NotNil(t, tx, "BEEF_V2 ParseBeef should return the main transaction")
+	require.NotNil(t, txid, "BEEF_V2 ParseBeef should return the main txid")
+	require.Equal(t, txid, tx.TxID(), "returned txid should match tx.TxID()")
+}
+
+func TestParseBeefV2TxIDNoPanic(t *testing.T) {
+	// Regression test for https://github.com/bsv-blockchain/go-sdk/issues/306
+	// Calling TxID() on the transaction returned by ParseBeef should not panic.
+	beefBytes, err := hex.DecodeString(BEEFSet)
+	require.NoError(t, err)
+
+	_, tx, _, err := ParseBeef(beefBytes)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.NotPanics(t, func() {
+		txid := tx.TxID()
+		require.NotNil(t, txid)
+		t.Log(txid.String())
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #306

- `ParseBeef()` returned `(beef, nil, nil, nil)` for BEEF_V2 data, causing a nil pointer panic when callers called `.TxID()` on the returned transaction
- Added `NewestTxID` field to `Beef` struct, set during parsing by tracking the last transaction in the serialized BEEF (the "main" transaction per BEEF convention)
- `ParseBeef` BEEF_V2 case now returns the main transaction and its txid, matching ATOMIC_BEEF and BEEF_V1 behavior

## Test plan

- [x] New `TestParseBeefV2ReturnsTxAndTxID` verifies non-nil tx/txid returned for BEEF_V2
- [x] New `TestParseBeefV2TxIDNoPanic` regression test for #306 — asserts no panic on `.TxID()`
- [x] Existing `TestParseBeefV2` (empty BEEF) still passes with nil tx/txid
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)