### PR TITLE
fix: revert changes with reference in create/list actions

### DIFF
--- a/util/reader.go
+++ b/util/reader.go
@@ -426,6 +426,15 @@ func (r *ReaderHoldError) ReadString(errMsg ...string) string {
 	return val
 }
 
+func (r *ReaderHoldError) ReadOptionalString() string {
+	if r.Err != nil {
+		return ""
+	}
+	val, err := r.Reader.ReadOptionalString()
+	r.Err = err
+	return val
+}
+
 func (r *ReaderHoldError) ReadStringSlice() []string {
 	if r.Err != nil {
 		return nil

--- a/util/reader.go
+++ b/util/reader.go
@@ -426,15 +426,6 @@ func (r *ReaderHoldError) ReadString(errMsg ...string) string {
 	return val
 }
 
-func (r *ReaderHoldError) ReadOptionalString() string {
-	if r.Err != nil {
-		return ""
-	}
-	val, err := r.Reader.ReadOptionalString()
-	r.Err = err
-	return val
-}
-
 func (r *ReaderHoldError) ReadStringSlice() []string {
 	if r.Err != nil {
 		return nil

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -172,7 +172,6 @@ type CreateActionArgs struct {
 	Version     *uint32              `json:"version,omitempty"`
 	Labels      []string             `json:"labels,omitempty"`
 	Options     *CreateActionOptions `json:"options,omitempty"`
-	Reference   *string              `json:"reference,omitempty"`
 }
 
 // CreateActionResult contains the results of creating a transaction
@@ -316,7 +315,6 @@ type ListActionsArgs struct {
 	Limit                            *uint32   `json:"limit,omitempty"` // Default 10, max 10000
 	Offset                           *uint32   `json:"offset,omitempty"`
 	SeekPermission                   *bool     `json:"seekPermission,omitempty"` // Default true
-	Reference                        *string   `json:"reference,omitempty"`
 }
 
 // ListActionsResult contains a paginated list of wallet transactions matching the query.

--- a/wallet/serializer/create_action_args.go
+++ b/wallet/serializer/create_action_args.go
@@ -2,7 +2,6 @@ package serializer
 
 import (
 	"fmt"
-
 	"github.com/bsv-blockchain/go-sdk/util"
 	"github.com/bsv-blockchain/go-sdk/wallet"
 )
@@ -37,11 +36,6 @@ func SerializeCreateActionArgs(args *wallet.CreateActionArgs) ([]byte, error) {
 	// Serialize options
 	if err := serializeCreateActionOptions(paramWriter, args.Options); err != nil {
 		return nil, fmt.Errorf("failed to serialize create action options: %w", err)
-	}
-
-	// Serialize reference (only if non-nil for backward ts compatibility)
-	if args.Reference != nil {
-		paramWriter.WriteOptionalString(*args.Reference)
 	}
 
 	return paramWriter.Buf, nil

--- a/wallet/serializer/create_action_args_deserialize.go
+++ b/wallet/serializer/create_action_args_deserialize.go
@@ -3,7 +3,6 @@ package serializer
 import (
 	"errors"
 	"fmt"
-
 	"github.com/bsv-blockchain/go-sdk/util"
 	"github.com/bsv-blockchain/go-sdk/wallet"
 )
@@ -47,14 +46,6 @@ func DeserializeCreateActionArgs(data []byte) (*wallet.CreateActionArgs, error) 
 		return nil, fmt.Errorf("error deserializing options: %w", err)
 	}
 	args.Options = options
-
-	// Read reference (optional - only if data is available for backward ts compatibility)
-	if !messageReader.IsComplete() {
-		ref := messageReader.ReadOptionalString()
-		if ref != "" {
-			args.Reference = &ref
-		}
-	}
 
 	messageReader.CheckComplete()
 	if messageReader.Err != nil {

--- a/wallet/serializer/create_action_args_test.go
+++ b/wallet/serializer/create_action_args_test.go
@@ -135,19 +135,6 @@ func TestCreateActionArgsSerializeAndDeserialize(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "with reference",
-			args: &wallet.CreateActionArgs{
-				Description: "transaction with reference",
-				Reference:   ptr("custom-reference-123"),
-				Outputs: []wallet.CreateActionOutput{
-					{
-						LockingScript: lockingScript,
-						Satoshis:      500,
-					},
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -223,8 +210,4 @@ func TestDeserializeCreateActionArgsErrors(t *testing.T) {
 			require.Contains(t, err.Error(), tt.err, "error message should contain expected substring")
 		})
 	}
-}
-
-func ptr(s string) *string {
-	return &s
 }

--- a/wallet/serializer/list_actions.go
+++ b/wallet/serializer/list_actions.go
@@ -48,11 +48,6 @@ func SerializeListActionsArgs(args *wallet.ListActionsArgs) ([]byte, error) {
 	w.WriteOptionalUint32(args.Offset)
 	w.WriteOptionalBool(args.SeekPermission)
 
-	// Serialize reference (only if non-nil for backward ts compatibility)
-	if args.Reference != nil {
-		w.WriteOptionalString(*args.Reference)
-	}
-
 	return w.Buf, nil
 }
 
@@ -87,14 +82,6 @@ func DeserializeListActionsArgs(data []byte) (*wallet.ListActionsArgs, error) {
 	args.Limit = r.ReadOptionalUint32()
 	args.Offset = r.ReadOptionalUint32()
 	args.SeekPermission = r.ReadOptionalBool()
-
-	// Deserialize reference (optional - only if data is available for backward ts compatibility)
-	if !r.IsComplete() {
-		ref := r.ReadOptionalString()
-		if ref != "" {
-			args.Reference = &ref
-		}
-	}
 
 	r.CheckComplete()
 	if r.Err != nil {

--- a/wallet/serializer/list_actions_test.go
+++ b/wallet/serializer/list_actions_test.go
@@ -2,8 +2,6 @@ package serializer
 
 import (
 	"encoding/hex"
-	"testing"
-
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/bsv-blockchain/go-sdk/util"
@@ -11,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 type ListActionArgsSerializeTest struct {
@@ -62,13 +61,6 @@ func TestListActionArgsSerializeAndDeserialize(t *testing.T) {
 				Limit:                            nil,
 				Offset:                           nil,
 				SeekPermission:                   nil,
-			},
-		},
-		{
-			name: "with reference",
-			args: wallet.ListActionsArgs{
-				Labels:    []string{"label1"},
-				Reference: ptr("custom-action-reference-456"),
 			},
 		},
 	}


### PR DESCRIPTION
## Description of Changes

This PR reverts the changes introduced in PR #289, which added an option to provide a custom reference for wallet actions.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment
- [ ] All tests pass when using `go test ./...`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review