### PR TITLE
fix: match uhrp url generation with ts sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Table of Contents
 
+- [1.2.20 - 2026-04-03](#1220---2026-04-03)
 - [1.2.19 - 2026-03-11](#1219---2026-03-11)
 - [1.2.18 - 2026-02-12](#1218---2026-02-12)
 - [1.2.17 - 2026-02-06](#1217---2026-02-06)
@@ -53,6 +54,11 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.1 - 2024-08-28](#111---2024-08-28)
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
+
+## [1.2.20] - 2026-04-03
+
+### Fixed
+- UHRP URL generation now uses Base58Check encoding with `[0xce, 0x00]` prefix, matching the TypeScript SDK (#310)
 
 ## [1.2.19] - 2026-03-11
 

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -14,7 +14,12 @@ const (
 	uhrpPrefix    = "uhrp://"
 	webPrefix     = "web+uhrp://"
 	minHashLength = 32
+	prefixLength  = 2
 )
+
+// uhrpBase58CheckPrefix is the 2-byte prefix [0xce, 0x00] used in Base58Check
+// encoding of UHRP URLs, matching the TypeScript SDK's
+var uhrpBase58CheckPrefix = []byte{0xce, 0x00}
 
 var (
 	// ErrInvalidHashLength is returned when a hash length is incorrect
@@ -42,19 +47,20 @@ func NormalizeURL(url string) string {
 	return url
 }
 
-// GetURLForHash generates a UHRP URL from a given SHA-256 hash
+// GetURLForHash generates a UHRP URL from a given SHA-256 hash using Base58Check encoding with a [0xce, 0x00] prefix.
 func GetURLForHash(hash []byte) (string, error) {
 	if len(hash) != minHashLength {
-		return "", errors.New("hash must be exactly 32 bytes (SHA-256)")
+		return "", ErrInvalidHashLength
 	}
 
-	// Append checksum (double SHA-256 of the hash, first 4 bytes)
-	checksum := crypto.Sha256d(hash)[:4]
-	data := append(hash, checksum...)
+	payload := make([]byte, 0, prefixLength+minHashLength+4)
+	payload = append(payload, uhrpBase58CheckPrefix...)
+	payload = append(payload, hash...)
 
-	// Encode with base58
-	encoded := base58.Encode(data)
-	return uhrpPrefix + encoded, nil
+	checksum := crypto.Sha256d(payload)[:4]
+	payload = append(payload, checksum...)
+
+	return base58.Encode(payload), nil
 }
 
 // GetURLForFile generates a UHRP URL for a file
@@ -63,7 +69,7 @@ func GetURLForFile(data []byte) (string, error) {
 	return GetURLForHash(hash)
 }
 
-// GetHashFromURL extracts the SHA-256 hash from a UHRP URL
+// GetHashFromURL extracts the SHA-256 hash from a UHRP URL.
 func GetHashFromURL(uhrpURL string) ([]byte, error) {
 	normalized := NormalizeURL(uhrpURL)
 
@@ -73,19 +79,25 @@ func GetHashFromURL(uhrpURL string) ([]byte, error) {
 		return nil, errors.New("invalid UHRP URL: base58 decode failed")
 	}
 
-	// Check minimum length (hash + checksum)
-	if len(decoded) < minHashLength+4 {
+	// Check minimum length: prefixLength (2) + hash (32) + checksum (4)
+	if len(decoded) != prefixLength+minHashLength+4 {
 		return nil, errors.New("invalid UHRP URL: too short after decoding")
 	}
 
-	// Split into hash and checksum
-	hash := decoded[:minHashLength]
-	checksum := decoded[minHashLength:]
+	// Split into prefix, hash, and checksum
+	prefix := decoded[:prefixLength]
+	hash := decoded[prefixLength : prefixLength+minHashLength]
+	checksum := decoded[prefixLength+minHashLength:]
 
-	// Verify checksum
-	expectedChecksum := crypto.Sha256d(hash)[:4]
+	// Validate prefix
+	if !bytes.Equal(prefix, uhrpBase58CheckPrefix) {
+		return nil, ErrInvalidURLPrefix
+	}
+
+	// Verify checksum over prefix + hash
+	expectedChecksum := crypto.Sha256d(decoded[:prefixLength+minHashLength])[:4]
 	if !bytes.Equal(checksum, expectedChecksum) {
-		return nil, errors.New("invalid UHRP URL: checksum verification failed")
+		return nil, ErrInvalidChecksum
 	}
 
 	return hash, nil

--- a/storage/utils_test.go
+++ b/storage/utils_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test vectors from the TypeScript SDK's StorageUtils.test.ts to test compatibility
+const (
+	tsTestHashHex = "1a5ec49a3f32cd56d19732e89bde5d81755ddc0fd8515dc8b226d47654139dca"
+	tsTestURL     = "XUT6PqWb3GP3LR7dmBMCJwZ3oo5g1iGCF3CrpzyuJCemkGu1WGoq"
+	tsTestFileHex = "687da27f04a112aa48f1cab2e7949f1eea4f7ba28319c1e999910cd561a634a05a3516e6db"
+)
+
 func TestNormalizeURL(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -39,6 +46,11 @@ func TestNormalizeURL(t *testing.T) {
 			input:    "WEB+UHRP://abcdef12345",
 			expected: "abcdef12345",
 		},
+		{
+			name:     "new base58check format unchanged",
+			input:    tsTestURL,
+			expected: tsTestURL,
+		},
 	}
 
 	for _, tt := range tests {
@@ -49,85 +61,83 @@ func TestNormalizeURL(t *testing.T) {
 	}
 }
 
+func TestGetURLForHash_MatchesTypeScriptSDK(t *testing.T) {
+	// This is the primary cross-SDK compatibility test.
+	// The expected URL must match the TypeScript SDK's output exactly.
+	testHash, err := hex.DecodeString(tsTestHashHex)
+	require.NoError(t, err)
+
+	url, err := GetURLForHash(testHash)
+	require.NoError(t, err)
+	assert.Equal(t, tsTestURL, url, "GetURLForHash output must match TypeScript SDK test vector")
+}
+
 func TestGetURLForHashAndGetHashFromURL(t *testing.T) {
-	// Sample test data - use a known hash
-	testHash, err := hex.DecodeString("1a5ec49a3f32cd56d19732e89bde5d81755ddc0fd8515dc8b226d47654139dca")
+	testHash, err := hex.DecodeString(tsTestHashHex)
 	require.NoError(t, err)
 
 	// Generate URL from hash
 	url, err := GetURLForHash(testHash)
 	require.NoError(t, err)
 
-	// Make sure URL is not empty and looks reasonable
+	// Make sure URL is not empty and matches expected format
 	assert.NotEmpty(t, url)
-	assert.True(t, len(url) > 10)
+	assert.Equal(t, tsTestURL, url)
 	assert.True(t, IsValidURL(url))
 
-	// Extract hash from URL
+	// Extract hash back from URL — round-trip test
 	extractedHash, err := GetHashFromURL(url)
-	require.NoError(t, err)
-
-	// Hash should match original
-	assert.Equal(t, testHash, extractedHash)
-
-	// Test with protocol prefix
-	urlWithPrefix := "uhrp://" + NormalizeURL(url)
-	extractedHash, err = GetHashFromURL(urlWithPrefix)
-	require.NoError(t, err)
-	assert.Equal(t, testHash, extractedHash)
-
-	// Test with web protocol prefix
-	webUrlWithPrefix := "web+uhrp://" + NormalizeURL(url)
-	extractedHash, err = GetHashFromURL(webUrlWithPrefix)
 	require.NoError(t, err)
 	assert.Equal(t, testHash, extractedHash)
 }
 
 func TestGetURLForFile(t *testing.T) {
-	// Sample file content from TypeScript tests
-	fileHex := "687da27f04a112aa48f1cab2e7949f1eea4f7ba28319c1e999910cd561a634a05a3516e6db"
-	fileBytes, err := hex.DecodeString(fileHex)
+	fileBytes, err := hex.DecodeString(tsTestFileHex)
 	require.NoError(t, err)
 
-	// Generate URL for file
+	// The TS test asserts that getURLForFile(exampleFile) == exampleURL
 	url, err := GetURLForFile(fileBytes)
 	require.NoError(t, err)
-
-	// URL should not be empty
-	assert.NotEmpty(t, url)
-
-	// We should be able to validate the URL
+	assert.Equal(t, tsTestURL, url, "GetURLForFile must match TypeScript SDK test vector")
 	assert.True(t, IsValidURL(url))
 }
 
+func TestGetHashFromURL_WithProtocolPrefix(t *testing.T) {
+	testHash, err := hex.DecodeString(tsTestHashHex)
+	require.NoError(t, err)
+
+	// Test with uhrp:// prefix (NormalizeURL strips it, then we decode the base58check)
+	urlWithPrefix := "uhrp://" + tsTestURL
+	extractedHash, err := GetHashFromURL(urlWithPrefix)
+	require.NoError(t, err)
+	assert.Equal(t, testHash, extractedHash)
+
+	// Test with web+uhrp:// prefix
+	webUrlWithPrefix := "web+uhrp://" + tsTestURL
+	extractedHash, err = GetHashFromURL(webUrlWithPrefix)
+	require.NoError(t, err)
+	assert.Equal(t, testHash, extractedHash)
+}
+
 func TestIsValidURL(t *testing.T) {
-	// Sample test data - use a known hash
-	testHash, err := hex.DecodeString("1a5ec49a3f32cd56d19732e89bde5d81755ddc0fd8515dc8b226d47654139dca")
-	require.NoError(t, err)
-
-	// Generate valid URL from hash
-	validURL, err := GetURLForHash(testHash)
-	require.NoError(t, err)
-
-	// Test various URL forms
 	tests := []struct {
 		name     string
 		input    string
 		expected bool
 	}{
 		{
-			name:     "valid URL",
-			input:    validURL,
+			name:     "valid URL - new format",
+			input:    tsTestURL,
 			expected: true,
 		},
 		{
-			name:     "valid URL with protocol prefix",
-			input:    "uhrp://" + NormalizeURL(validURL),
+			name:     "valid URL with uhrp:// prefix",
+			input:    "uhrp://" + tsTestURL,
 			expected: true,
 		},
 		{
-			name:     "valid URL with web protocol prefix",
-			input:    "web+uhrp://" + NormalizeURL(validURL),
+			name:     "valid URL with web+uhrp:// prefix",
+			input:    "web+uhrp://" + tsTestURL,
 			expected: true,
 		},
 		{
@@ -141,8 +151,8 @@ func TestIsValidURL(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "invalid URL - modified valid URL",
-			input:    validURL[:len(validURL)-1] + "X",
+			name:     "invalid URL - modified valid URL (bad checksum)",
+			input:    tsTestURL[:len(tsTestURL)-1] + "X",
 			expected: false,
 		},
 	}
@@ -166,17 +176,13 @@ func TestGetHashFromURL_InvalidInputs(t *testing.T) {
 	_, err := GetHashFromURL("not-base58")
 	assert.Error(t, err)
 
-	// Create a URL with a valid hash but modify the checksum
-	testHash, err := hex.DecodeString("1a5ec49a3f32cd56d19732e89bde5d81755ddc0fd8515dc8b226d47654139dca")
-	require.NoError(t, err)
+	// Modify a valid URL to invalidate the checksum
+	invalidURL := tsTestURL[:len(tsTestURL)-1] + "X"
+	_, err = GetHashFromURL(invalidURL)
+	assert.Error(t, err)
 
-	validURL, err := GetURLForHash(testHash)
-	require.NoError(t, err)
-
-	// Modify the last character to invalidate the checksum
-	if len(validURL) > 0 {
-		invalidURL := validURL[:len(validURL)-1] + "X"
-		_, err = GetHashFromURL(invalidURL)
-		assert.Error(t, err)
-	}
+	// TS SDK test: known bad checksum URL
+	badChecksumURL := "XUU7cTfy6fA6q2neLDmzPqJnGB6o18PXKoGaWLPrH1SeWLKgdCKq"
+	_, err = GetHashFromURL(badChecksumURL)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Description of Changes

Update the URL generation methods in uhrp to align them with the results from ts-sdk and ensure compatibility

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment
- [ ] All tests pass when using `go test ./...`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review