### PR TITLE
update changelog for v1.2.20 and v1.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Table of Contents
 
-- [1.2.20 - 2026-04-03](#1220---2026-04-03)
+- [1.2.21 - 2026-04-03](#1221---2026-04-03)
+- [1.2.20 - 2026-03-26](#1220---2026-03-26)
 - [1.2.19 - 2026-03-11](#1219---2026-03-11)
 - [1.2.18 - 2026-02-12](#1218---2026-02-12)
 - [1.2.17 - 2026-02-06](#1217---2026-02-06)
@@ -55,10 +56,20 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
 
-## [1.2.20] - 2026-04-03
+## [1.2.21] - 2026-04-03
 
 ### Fixed
 - UHRP URL generation now uses Base58Check encoding with `[0xce, 0x00]` prefix, matching the TypeScript SDK (#310)
+
+## [1.2.20] - 2026-03-26
+
+### Fixed
+- Resolved panic when calling `TxID()` on BEEF_V2 parsed transaction (#307)
+- Resolved security-related vulnerabilities flagged by SonarCloud (#303)
+
+### Changed
+- Implemented BSV Chronicle Op Code Fidelity Pass and Compound Merkle Path Assurances (#304)
+- Increased test coverage from 62.3% to 80.3% (#305)
 
 ## [1.2.19] - 2026-03-11
 


### PR DESCRIPTION
## Summary
- Add missing changelog entry for v1.2.20
- Rename the UHRP fix changelog entry to v1.2.21