### PR TITLE
fix(overlay): increase default timeouts and make them configurable

### DIFF
--- a/overlay/lookup/resolver.go
+++ b/overlay/lookup/resolver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/bsv-blockchain/go-sdk/transaction"
 )
 
-const MAX_TRACKER_WAIT_TIME = time.Second
+const MAX_TRACKER_WAIT_TIME = 30 * time.Second
 
 var DEFAULT_SLAP_TRACKERS = []string{
 	// BSVA clusters
@@ -34,6 +34,9 @@ type LookupResolver struct {
 	HostOverrides   map[string][]string
 	AdditionalHosts map[string][]string
 	NetworkPreset   overlay.Network
+	// TrackerTimeout overrides MAX_TRACKER_WAIT_TIME for SLAP tracker queries.
+	// Zero value uses the default.
+	TrackerTimeout time.Duration
 }
 
 // NewLookupResolver creates a new LookupResolver with the provided configuration
@@ -44,6 +47,7 @@ func NewLookupResolver(cfg *LookupResolver) *LookupResolver {
 		HostOverrides:   cfg.HostOverrides,
 		AdditionalHosts: cfg.AdditionalHosts,
 		NetworkPreset:   cfg.NetworkPreset,
+		TrackerTimeout:  cfg.TrackerTimeout,
 	}
 	if resolver.Facilitator == nil {
 		resolver.Facilitator = &HTTPSOverlayLookupFacilitator{
@@ -153,13 +157,18 @@ func (l *LookupResolver) FindCompetentHosts(ctx context.Context, service string)
 		return nil, fmt.Errorf("error marshalling query: %w", err)
 	}
 
+	trackerTimeout := l.TrackerTimeout
+	if trackerTimeout == 0 {
+		trackerTimeout = MAX_TRACKER_WAIT_TIME
+	}
+
 	responses := make(chan *LookupAnswer, len(l.SLAPTrackers))
 	var wg sync.WaitGroup
 	for _, url := range l.SLAPTrackers {
 		wg.Add(1)
 		go func(url string) {
 			defer wg.Done()
-			ctxWithTimeout, cancel := context.WithTimeout(ctx, MAX_TRACKER_WAIT_TIME)
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, trackerTimeout)
 			defer cancel()
 
 			if answer, err := l.Facilitator.Lookup(ctxWithTimeout, url, query); err != nil {

--- a/overlay/topic/facilitator.go
+++ b/overlay/topic/facilitator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bsv-blockchain/go-sdk/util"
 )
 
-const MAX_SHIP_QUERY_TIMEOUT = 5 * time.Second
+const MAX_SHIP_QUERY_TIMEOUT = 30 * time.Second
 
 // Facilitator defines the interface for overlay broadcast facilitators that can send tagged BEEF to overlay services
 type Facilitator interface {
@@ -22,11 +22,17 @@ type Facilitator interface {
 // HTTPSOverlayBroadcastFacilitator implements the Facilitator interface using HTTPS requests for broadcasting transactions
 type HTTPSOverlayBroadcastFacilitator struct {
 	Client util.HTTPClient
+	// Timeout overrides MAX_SHIP_QUERY_TIMEOUT for each submit request. Zero value uses the default.
+	Timeout time.Duration
 }
 
 // Send broadcasts a tagged BEEF transaction to the specified overlay service URL and returns the STEAK response
 func (f *HTTPSOverlayBroadcastFacilitator) Send(url string, taggedBEEF *overlay.TaggedBEEF) (*overlay.Steak, error) {
-	timeoutContext, cancel := context.WithTimeout(context.Background(), MAX_SHIP_QUERY_TIMEOUT)
+	timeout := f.Timeout
+	if timeout == 0 {
+		timeout = MAX_SHIP_QUERY_TIMEOUT
+	}
+	timeoutContext, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(timeoutContext, "POST", url+"/submit", bytes.NewBuffer(taggedBEEF.Beef))


### PR DESCRIPTION
## Problem

`MAX_TRACKER_WAIT_TIME = 1s` and `MAX_SHIP_QUERY_TIMEOUT = 5s` are too short for real-world overlay infrastructure. Trackers like `overlay-us-1.bsvb.tech` routinely respond in 2–10s, causing reliable `context deadline exceeded` failures during SLAP discovery and SHIP broadcast.

## Changes

**`overlay/lookup/resolver.go`**
- `MAX_TRACKER_WAIT_TIME`: `1s` → `30s`
- `LookupResolver.TrackerTimeout` field: overrides the default per-instance (zero = use default)

**`overlay/topic/facilitator.go`**
- `MAX_SHIP_QUERY_TIMEOUT`: `5s` → `30s`
- `HTTPSOverlayBroadcastFacilitator.Timeout` field: overrides the default per-instance (zero = use default)

## Backwards compatibility

Fully backwards-compatible. New fields use zero-value-means-default semantics, so existing code constructing these structs without the new fields continues to work and now gets the improved defaults.