### PR TITLE
fix(beef): set BUMP index when merging rawtx to BEEF

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -700,6 +700,7 @@ func (b *Beef) MergeRawTx(rawTx []byte, bumpIndex *int) (*BeefTx, error) {
 		}
 		beefTx.Transaction.MerklePath = b.BUMPs[*bumpIndex]
 		beefTx.DataFormat = RawTxAndBumpIndex
+		beefTx.BumpIndex = *bumpIndex
 	}
 
 	b.Transactions[*txid] = beefTx


### PR DESCRIPTION
## Description of Changes

`Beef.MergeRawTx` (`transaction/beef.go`) sets `beefTx.Transaction.MerklePath` and `beefTx.DataFormat = RawTxAndBumpIndex` when a `bumpIndex` is provided, but **never assigns `beefTx.BumpIndex = *bumpIndex`**. The sibling `MergeTransactionWithTxid` does this correctly. The wire-format serializer encodes `tx.BumpIndex` directly, so the bug only surfaces after serialization.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment
- [x] All tests pass when using `go test ./...`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [x] I ran `golangci-lint run`
- [x] I have run `go fmt` and `go vet` one final time before requesting a review