### PR TITLE
fix(transaction): stop attaching an empty tx to a TxIDOnly BEEF entry

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -148,7 +148,9 @@ func readBeefTxFull(reader *bytes.Reader, beefTx *BeefTx, BUMPs []*MerklePath, t
 	}
 
 	for _, input := range beefTx.Transaction.Inputs {
-		if sourceObj, ok := txs[*input.SourceTXID]; ok {
+		// A source held as a bare txid has no transaction to link to. Linking one
+		// anyway leaves the input pointing at something it cannot spend.
+		if sourceObj, ok := txs[*input.SourceTXID]; ok && sourceObj.Transaction != nil {
 			input.SourceTransaction = sourceObj.Transaction
 		}
 	}
@@ -170,8 +172,7 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 			return nil, nil, err
 		}
 		beefTx := BeefTx{
-			DataFormat:  DataFormat(formatByte),
-			Transaction: &Transaction{},
+			DataFormat: DataFormat(formatByte),
 		}
 		if beefTx.DataFormat > TxIDOnly {
 			return nil, nil, fmt.Errorf("invalid data format: %d", formatByte)
@@ -179,8 +180,14 @@ func readBeefTx(reader *bytes.Reader, BUMPs []*MerklePath) (*map[chainhash.Hash]
 
 		var txid *chainhash.Hash
 		if beefTx.DataFormat == TxIDOnly {
+			// A TxIDOnly entry has no transaction, only a txid. Leave
+			// Transaction nil, matching what MergeTxidOnly builds in memory: an
+			// empty placeholder would be a transaction with no inputs and no
+			// outputs, which every consumer of a raw entry then has to defend
+			// against.
 			txid, err = readBeefTxIDOnly(reader, &beefTx)
 		} else {
+			beefTx.Transaction = &Transaction{}
 			txid, err = readBeefTxFull(reader, &beefTx, BUMPs, txs)
 		}
 		if err != nil {

--- a/transaction/beef_txidonly_test.go
+++ b/transaction/beef_txidonly_test.go
@@ -1,0 +1,95 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A TxIDOnly entry carries a txid and no transaction: that is the shape
+// MergeTxidOnly builds, and what ValidateTransactions, String and the writer all
+// read. The reader has to produce the same shape, or a round trip through the
+// wire format turns a bare txid into a bare txid PLUS an empty transaction -
+// which then gets linked into whatever spends it, panics SourceTxOutput, and
+// merges into other graphs as a transaction of its own.
+
+func TestNewBeefFromBytesLeavesNoTransactionOnATxIDOnlyEntry(t *testing.T) {
+	parent := benchTx(0)
+	child := benchTx(1, parent)
+
+	beef := NewBeefV2()
+	_, err := beef.MergeRawTx(child.Bytes(), nil)
+	require.NoError(t, err)
+	beef.MergeTxidOnly(parent.TxID())
+
+	raw, err := beef.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := NewBeefFromBytes(raw)
+	require.NoError(t, err)
+
+	parentEntry := parsed.Transactions[*parent.TxID()]
+	require.NotNil(t, parentEntry)
+	assert.Equal(t, TxIDOnly, parentEntry.DataFormat)
+	assert.Nil(t, parentEntry.Transaction, "a bare txid must not come back with a transaction attached")
+	require.NotNil(t, parentEntry.KnownTxID)
+	assert.Equal(t, *parent.TxID(), *parentEntry.KnownTxID)
+
+	childEntry := parsed.Transactions[*child.TxID()]
+	require.NotNil(t, childEntry)
+	require.NotNil(t, childEntry.Transaction)
+	require.Len(t, childEntry.Transaction.Inputs, 1)
+	assert.Nil(t, childEntry.Transaction.Inputs[0].SourceTransaction,
+		"an input whose source is a bare txid must not be linked to a transaction it cannot spend")
+}
+
+// Merging a parsed graph must not smuggle a placeholder in as an entry of its
+// own: MergeTransaction follows SourceTransaction pointers, so a linked
+// placeholder used to land in the target graph under the txid of an empty
+// transaction.
+func TestMergeBeefDoesNotIntroduceAPlaceholderForATxIDOnlyEntry(t *testing.T) {
+	parent := benchTx(0)
+	child := benchTx(1, parent)
+
+	source := NewBeefV2()
+	_, err := source.MergeRawTx(child.Bytes(), nil)
+	require.NoError(t, err)
+	source.MergeTxidOnly(parent.TxID())
+
+	raw, err := source.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := NewBeefFromBytes(raw)
+	require.NoError(t, err)
+
+	target := NewBeefV2()
+	require.NoError(t, target.MergeBeef(parsed))
+
+	emptyTxID := (&Transaction{}).TxID()
+	assert.NotContains(t, target.Transactions, *emptyTxID,
+		"the empty-transaction txid must never appear in a merged graph")
+
+	for txid, entry := range target.Transactions {
+		if entry.DataFormat == TxIDOnly {
+			continue
+		}
+		require.NotNilf(t, entry.Transaction, "entry %s has no transaction", txid)
+		assert.Falsef(t, len(entry.Transaction.Inputs) == 0 && len(entry.Transaction.Outputs) == 0,
+			"entry %s is an empty transaction", txid)
+	}
+}
+
+// SourceTxOutput used to index Outputs unchecked, so any input linked to a
+// transaction that does not carry the output it spends panicked.
+func TestSourceTxOutputDoesNotPanicWhenTheSourceLacksTheOutput(t *testing.T) {
+	input := &TransactionInput{
+		SourceTransaction: &Transaction{},
+		SourceTxOutIndex:  0,
+	}
+
+	assert.NotPanics(t, func() {
+		assert.Nil(t, input.SourceTxOutput())
+		assert.Nil(t, input.SourceTxScript())
+	})
+}

--- a/transaction/input.go
+++ b/transaction/input.go
@@ -41,9 +41,12 @@ type TransactionInput struct {
 }
 
 func (i *TransactionInput) SourceTxOutput() *TransactionOutput {
-	if i.SourceTransaction != nil {
+	if i.SourceTransaction != nil && int(i.SourceTxOutIndex) < len(i.SourceTransaction.Outputs) {
 		return i.SourceTransaction.Outputs[i.SourceTxOutIndex]
 	}
+	// The source transaction does not carry the output this input spends. Fall
+	// back to any output supplied directly; callers already handle nil, whereas
+	// indexing here panicked.
 	return i.sourceOutput
 }
 


### PR DESCRIPTION
## What Changed

A `TxIDOnly` BEEF entry carries a txid and **no** transaction. That is what `Beef.MergeTxidOnly` builds in memory, and what `ValidateTransactions`, `String` and the writer all read — none of them touch `Transaction` for such an entry.

`readBeefTx` did not produce that shape:

```go
beefTx := BeefTx{
    DataFormat:  DataFormat(formatByte),
    Transaction: &Transaction{},   // allocated for every entry
}
```

On the `TxIDOnly` path it was never filled in, so a round trip through the wire format turned a bare txid into **a bare txid plus an empty transaction** (version 0, no inputs, no outputs). `readBeefTxFull` then linked that placeholder into any later transaction spending it:

```go
if sourceObj, ok := txs[*input.SourceTXID]; ok {
    input.SourceTransaction = sourceObj.Transaction   // no data-format check
}
```

Three fixes:

- `readBeefTx` allocates `Transaction` only on the full-transaction path.
- `readBeefTxFull` links a source only when it has a transaction to link.
- `SourceTxOutput` bounds-checks the index and falls back to `sourceOutput` — which callers already handle as nil — instead of panicking.

The first two restore the invariant the rest of the package already assumes. The third is defence in depth for any other route into the same state.

## Why It Was Necessary

Three consequences, all observed in production on a wallet storage service:

1. **Remote panic.** `TransactionInput.SourceTxOutput` indexed `Outputs` without a bounds check, so touching such an input panicked. Any service that verifies scripts on a caller-supplied BEEF could be crashed by a single bare txid.

2. **The placeholder spreads.** `Beef.MergeTransaction` walks `SourceTransaction` pointers, so merging a parsed graph carried the placeholder into the target graph as a transaction of its own, under the txid of an empty transaction — `f702453dd03b0f055e5437d761281418…`. From there it travels through anything that stores or forwards the merged bytes. This is what an investigation into unexplained "floating empty transactions" in stored BEEFs turned out to be; it had been attributed to hand-rolled BEEF assembly in an application.

3. **Real ancestry could not be supplied.** Code that treats a non-nil `SourceTransaction` as "already resolved" kept the placeholder in preference to the real parent, so later attempts to merge in the genuine transaction had no effect.

The bug is only reachable once bare txids travel on the wire, which is why it went unnoticed: an in-memory graph built with `MergeTxidOnly` is correct, and only serialize→parse produces the bad shape. It is not a regression from #343.

## Testing Performed

New `transaction/beef_txidonly_test.go`, three cases — all three fail on `master` and pass with this change:

- `TestNewBeefFromBytesLeavesNoTransactionOnATxIDOnlyEntry` — round-trips a BEEF holding one raw tx and its parent as a bare txid; asserts the parsed entry has a nil `Transaction` and that the child's input is not linked to it. On `master`: `Expected nil, but got: &transaction.Transaction{Version:0x0, Inputs:nil, Outputs:nil, ...}`.
- `TestMergeBeefDoesNotIntroduceAPlaceholderForATxIDOnlyEntry` — merges the parsed graph into a fresh one and asserts the empty-transaction txid never appears, and that no entry is an empty transaction. On `master` the graph gains the `f702453d…` entry.
- `TestSourceTxOutputDoesNotPanicWhenTheSourceLacksTheOutput` — pins the bounds check. On `master`: panic.

Full `go test ./...` passes on this branch. `gofmt` clean.

## Impact / Risk

Low. No exported signatures change and no wire format changes.

Behaviour changes in three places:

- A `TxIDOnly` entry from the reader now has `Transaction == nil`, matching `MergeTxidOnly`. Any caller that read `entry.Transaction` on a `TxIDOnly` entry was reading an empty placeholder, so it could not have been getting useful data — but a caller dereferencing it without a nil check would now panic where it previously returned zero values. Nothing in this repo does; consumers that switch on `DataFormat` (the documented way) are unaffected.
- An input whose source is a bare txid now has `SourceTransaction == nil` rather than pointing at an empty transaction. This is what the type already means by nil, and `SourceTxScript` already returns nil for it.
- `SourceTxOutput` returns nil instead of panicking when the source lacks the output. Strictly wider input tolerance.

## Notifications
- @Deggen